### PR TITLE
Fix restarting GB Audio envelope when writing to register

### DIFF
--- a/code/core/arm7/source/Sound/GbEnvelope.c
+++ b/code/core/arm7/source/Sound/GbEnvelope.c
@@ -28,6 +28,8 @@ bool gbs_writeEnvelope(gbs_envelope_t* env, u16 value)
     env->direction = (value >> 3) & 1;
     env->initVolume = (value >> 4) & 0xF;
     updateDead(env);
+    if (!env->dead)
+         env->nextStep = env->stepTime;
     return (env->initVolume || env->direction) && env->dead != 2;
 }
 


### PR DESCRIPTION
As discussed [here](https://github.com/mgba-emu/mgba/issues/3067), this adds `nextStep` being updated in `_writeEnvelope`, so it emulates the same behavior observed in real GBA hardware, where the envelope updates even after it has been started.

This fixes Wario Land 4 jump sound sfx playing incorrectly, and the homebrew demo linked below.

https://github.com/mgba-emu/mgba/files/13360772/F0_F7_no_retrig.zip

Additionally, it's worth noting that the GBA hardware in NDS/3DS experiences this bug, as it doesn't behave like a GBA, so it never updates the envelopes after starting them, which  was the behavior prior to this change in GBARunner3 as well.

Tested on the following games which use the GB Channels intensively, with no observed regressions:

`Wario Land 4`
`Mega Man & Bass`
`Mega Man: Battle Network`
`Mario Kart Super Circuit`
`Game & Watch Gallery 4`
`The Legend of Zelda: The Minish Cap`
`Bomber Man MAX 2: Blue Advance`
`Castlevania: Harmony of Dissonance`
`GT Advance Championship Racing`

And `soundtest1.gba` to compare against real GBA hardware:

[soundtest1.zip](https://github.com/Gericom/GBARunner3/files/13789394/soundtest1.zip)

Play any sound and change `Envlp Step Dir` from `Inc` to `Dec` without playing the sound again, it should be correctly updated in real GBA hardware and this bug fix applied, but on NDS/3DS it should make an infinite beep sound instead, which is the expected bug.
