### PR TITLE
core: fix capitalization in header include

### DIFF
--- a/code/core/arm9/source/Application/GbaBorderService.h
+++ b/code/core/arm9/source/Application/GbaBorderService.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "common.h"
 #include <memory>
-#include "fat/File.h"
+#include "Fat/File.h"
 #include "Application/Settings/Enums/GbaBorderImage.h"
 
 class GbaBorderService


### PR DESCRIPTION
Fixes small build error in Linux. Not that it means much, because `ld` is still being annoying AF.