### PR TITLE
core: arm9: reverse the order of SFILES

### DIFF
--- a/code/core/arm9/Makefile
+++ b/code/core/arm9/Makefile
@@ -98,7 +98,8 @@ export DEPSDIR	:=	$(CURDIR)/$(BUILD)
 
 CFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.c)))
 CPPFILES	:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.cpp)))
-SFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.s)))
+SFILES_UNSORTED	:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.s)))
+SFILES		:=	$(shell for i in $(SFILES_UNSORTED); do echo $$i; done | sort -r)
 BINFILES	:=	$(foreach dir,$(DATA),$(notdir $(wildcard $(dir)/*.*)))
 
 #---------------------------------------------------------------------------------


### PR DESCRIPTION
Along with the remainder of commits on the existing feature branch, this fixes compilation on Unix-like platforms (such as Linux.)