### PR TITLE
Include string.h in ff.c

### DIFF
--- a/code/core/arm9/source/Fat/ff.c
+++ b/code/core/arm9/source/Fat/ff.c
@@ -18,6 +18,7 @@
 /
 /----------------------------------------------------------------------------*/
 
+#include <string.h>
 #include "common.h"
 #include <libtwl/mem/memSwap.h>
 #include "MemCopy.h"


### PR DESCRIPTION
ff.c was using `malloc` without any prior definition, up until GCC 13 that was diagnosed as a warning, since it was allowed, but now GCC 14 is treating `-Wimplicit-function-declaration` as errors by default