### PR TITLE
Add support for IPS and UPS patching via GPO cluster interweaving

### DIFF
--- a/code/core/arm9/source/Application/SplashScreen.cpp
+++ b/code/core/arm9/source/Application/SplashScreen.cpp
@@ -11,8 +11,25 @@
 
 #define ANIM_GBARUNNER_FULLY_SHOWN_FRAMES   24
 #define ANIM_GBARUNNER_TOTAL_FRAMES         105
+#define GLOW_ALPHA_MAX                       16
+#define GLOW_RISE_FRAMES                     16
+#define GLOW_FALL_FRAMES                      6
+// Slower than the one-shot intro pulse above: this one repeats indefinitely while busy,
+// so a fast cycle reads as frantic in a way a single intro pulse never does.
+#define BUSY_GLOW_RISE_FRAMES                48
+#define BUSY_GLOW_FALL_FRAMES                18
 
-void SplashScreen::Initialize()
+[[gnu::section(".ewram")]] void SplashScreen::EnterBusyLoop() { _busy = true; }
+
+[[gnu::section(".ewram")]] void SplashScreen::ExitBusyLoop()
+{
+    _busy = false;
+    // The busy-loop pulse can end mid-ramp at an arbitrary brightness; settle back to the
+    // resting "no glow" state immediately instead of freezing on whatever value was last drawn.
+    REG_BLDALPHA = GLOW_ALPHA_MAX << 8;
+}
+
+[[gnu::section(".ewram")]] void SplashScreen::Initialize()
 {
     REG_BG0CNT = 0x0202;
     REG_BG1CNT = 0x0304;
@@ -23,7 +40,7 @@ void SplashScreen::Initialize()
 
     REG_DISPCNT = 0x10000 | (1 << 8) | (1 << 9) | (1 << 12) | (1 << 4) | (1 << 13) | 0;
 
-    REG_BLDALPHA = 16 << 8;
+    REG_BLDALPHA = GLOW_ALPHA_MAX << 8;
     REG_BLDCNT = (1 << 8) | (1 << 13) | (1 << 12) | (1 << 1) | (1 << 6);
 
     sys_setMainEngineToTopScreen();
@@ -33,13 +50,26 @@ void SplashScreen::Initialize()
 
     _frame = 0;
     _gbarunnerTextAnimator = Animator<int>(-43, 173, ANIM_GBARUNNER_FULLY_SHOWN_FRAMES, &gLinearCurve);
-    _threeGlowAnimator = Animator<int>(0, 16, 16, &gLinearCurve);
+    _threeGlowAnimator = Animator<int>(0, GLOW_ALPHA_MAX, GLOW_RISE_FRAMES, &gLinearCurve);
 }
 
-void SplashScreen::VBlank()
+[[gnu::section(".ewram")]] void SplashScreen::VBlank()
 {
     if (IsFinished())
     {
+        if (!_busy) return;
+
+        // Keep the existing glow pulse oscillating indefinitely instead of letting
+        // it settle at 0 once boot work outlasts the intro animation. Uses its own
+        // (slower) timing than the intro's one-shot pulse, since a fast cycle reads
+        // as frantic once it's repeating indefinitely instead of playing once.
+        if (_threeGlowAnimator.Update())
+        {
+            int next = _threeGlowAnimator.GetValue() == 0 ? GLOW_ALPHA_MAX : 0;
+            int duration = (next == GLOW_ALPHA_MAX) ? BUSY_GLOW_RISE_FRAMES : BUSY_GLOW_FALL_FRAMES;
+            _threeGlowAnimator.Goto(next, duration, &gLinearCurve);
+        }
+        REG_BLDALPHA = _threeGlowAnimator.GetValue() | ((GLOW_ALPHA_MAX - _threeGlowAnimator.GetValue()) << 8);
         return;
     }
 
@@ -63,7 +93,7 @@ void SplashScreen::VBlank()
     {
         if (_threeGlowAnimator.Update() && _threeGlowAnimator.GetValue() != 0)
         {
-            _threeGlowAnimator.Goto(0, 6, &gLinearCurve);
+            _threeGlowAnimator.Goto(0, GLOW_FALL_FRAMES, &gLinearCurve);
         }
     }
 
@@ -71,13 +101,13 @@ void SplashScreen::VBlank()
     gfx_setWindow0(std::max(0, _gbarunnerTextAnimator.GetValue() + 20), 82, 255, 110);
     if (_frame >= ANIM_GBARUNNER_FULLY_SHOWN_FRAMES)
     {
-        REG_BLDALPHA = _threeGlowAnimator.GetValue() | ((16 - _threeGlowAnimator.GetValue()) << 8);
+        REG_BLDALPHA = _threeGlowAnimator.GetValue() | ((GLOW_ALPHA_MAX - _threeGlowAnimator.GetValue()) << 8);
     }
     REG_MASTER_BRIGHT = 0;
     _frame++;
 }
 
-bool SplashScreen::IsFinished()
+[[gnu::section(".ewram")]] bool SplashScreen::IsFinished()
 {
     return _frame >= ANIM_GBARUNNER_TOTAL_FRAMES;
 }

--- a/code/core/arm9/source/Application/SplashScreen.h
+++ b/code/core/arm9/source/Application/SplashScreen.h
@@ -8,9 +8,12 @@ public:
     void Initialize();
     void VBlank();
     bool IsFinished();
+    void EnterBusyLoop();
+    void ExitBusyLoop();
 
 private:
     int _frame = 0;
+    volatile bool _busy = false;
     OamManager _mainOamManager;
     Animator<int> _gbarunnerTextAnimator;
     Animator<int> _threeGlowAnimator;

--- a/code/core/arm9/source/Crc32Table.cpp
+++ b/code/core/arm9/source/Crc32Table.cpp
@@ -1,0 +1,5 @@
+#include "common.h"
+#include "Crc32Table.h"
+
+[[gnu::section(".ewram")]]
+const Crc32Table gCrc32Table { };

--- a/code/core/arm9/source/Crc32Table.h
+++ b/code/core/arm9/source/Crc32Table.h
@@ -1,0 +1,23 @@
+#pragma once
+
+class Crc32Table
+{
+    u32 _table[256];
+
+public:
+    constexpr Crc32Table()
+        : _table()
+    {
+        for (u32 i = 0; i < 256; i++)
+        {
+            u32 c = i;
+            for (int k = 0; k < 8; k++)
+                c = (c & 1) ? (0xEDB88320u ^ (c >> 1)) : (c >> 1);
+            _table[i] = c;
+        }
+    }
+
+    constexpr u32 Table(u8 index) const { return _table[index]; }
+};
+
+extern const Crc32Table gCrc32Table;

--- a/code/core/arm9/source/MemoryEmulator/HiCodeCacheMapping.s
+++ b/code/core/arm9/source/MemoryEmulator/HiCodeCacheMapping.s
@@ -51,11 +51,6 @@ notHicodeMiss:
     ldr r11, [r8]
     b vm_undefinedArmInstructionInLR
 
-.bss
-
-// will be filled with HICODE_UNDEFINED_INSTRUCTION for fast prefetching
-.global gHicodeUndefinedData
-gHicodeUndefinedData:
-.space 2048
-
 #endif
+
+

--- a/code/core/arm9/source/MemoryEmulator/HiCodeCacheMappingC.c
+++ b/code/core/arm9/source/MemoryEmulator/HiCodeCacheMappingC.c
@@ -13,6 +13,9 @@ struct
     u32 hicodeBlockMask;
 } gHicodeState;
 
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+u32 gHicodeUndefinedData[2048 / 4];
+
 static inline u32 mpu_getRegion4(void)
 {
     u32 config;
@@ -147,6 +150,9 @@ void hic_initialize(void)
     {
         gHicodeUndefinedData[i] = HICODE_UNDEFINED_INSTRUCTION;
     }
+
+    // Flush the data cache so that instruction prefetch loads correct values from main memory
+    dc_flushRange(gHicodeUndefinedData, 2048);
 
     u32 irqs = arm_disableIrqs();
     {

--- a/code/core/arm9/source/Patches/GpoBuilder.cpp
+++ b/code/core/arm9/source/Patches/GpoBuilder.cpp
@@ -1,0 +1,514 @@
+#include "GpoBuilder.h"
+#include "PopCountTable.h"
+#include <string.h>
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static FIL sLogFile;
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static char sLogPath[256];
+
+[[gnu::section(".ewram")]] void gpo_getPath(const char* romPath, char* outPath, const char* ext)
+{
+    strcpy(outPath, romPath);
+    char* dot = strrchr(outPath, '.');
+    if (dot)
+        strcpy(dot, ext);
+    else
+        strcat(outPath, ext);
+}
+
+[[gnu::section(".ewram")]] static void u32_to_str(u32 val, char* buf)
+{
+    char temp[16];
+    int i = 0;
+    if (val == 0)
+    {
+        buf[0] = '0';
+        buf[1] = '\0';
+        return;
+    }
+    while (val > 0)
+    {
+        temp[i++] = '0' + (val % 10);
+        val /= 10;
+    }
+    for (int j = 0; j < i; j++)
+        buf[j] = temp[i - 1 - j];
+    buf[i] = '\0';
+}
+
+[[gnu::section(".ewram")]] void log_debug(const char* romPath, const char* msg, u32 val1, u32 val2)
+{
+    gpo_getPath(romPath, sLogPath, "_gpo.log");
+    if (f_open(&sLogFile, sLogPath, FA_WRITE | FA_OPEN_ALWAYS) == FR_OK)
+    {
+        f_lseek(&sLogFile, f_size(&sLogFile));
+        UINT bw;
+        f_write(&sLogFile, msg, strlen(msg), &bw);
+        if (val1 != 0xFFFFFFFF)
+        {
+            char valBuf[16];
+            u32_to_str(val1, valBuf);
+            f_write(&sLogFile, " val1: ", 7, &bw);
+            f_write(&sLogFile, valBuf, strlen(valBuf), &bw);
+        }
+        if (val2 != 0xFFFFFFFF)
+        {
+            char valBuf[16];
+            u32_to_str(val2, valBuf);
+            f_write(&sLogFile, " val2: ", 7, &bw);
+            f_write(&sLogFile, valBuf, strlen(valBuf), &bw);
+        }
+        f_write(&sLogFile, "\n", 1, &bw);
+        f_close(&sLogFile);
+    }
+}
+
+[[gnu::section(".ewram")]] void log_table(const char* romPath, const DWORD* tbl)
+{
+    gpo_getPath(romPath, sLogPath, "_gpo.log");
+    if (f_open(&sLogFile, sLogPath, FA_WRITE | FA_OPEN_ALWAYS) == FR_OK)
+    {
+        f_lseek(&sLogFile, f_size(&sLogFile));
+        UINT bw;
+        f_write(&sLogFile, "--- Merged Linkmap ---\n", 23, &bw);
+        u32 totalDwords = tbl[0];
+        char szBuf[16];
+        u32_to_str(totalDwords, szBuf);
+        f_write(&sLogFile, "Total DWORDs: ", 14, &bw);
+        f_write(&sLogFile, szBuf, strlen(szBuf), &bw);
+        f_write(&sLogFile, "\n", 1, &bw);
+
+        for (u32 i = 1; i < totalDwords; i += 2)
+        {
+            char idxBuf[16], sizeBuf[16], startBuf[16];
+            u32_to_str(i / 2, idxBuf);
+            u32_to_str(tbl[i], sizeBuf);
+            u32_to_str(tbl[i+1], startBuf);
+
+            f_write(&sLogFile, " Frag ", 6, &bw);
+            f_write(&sLogFile, idxBuf, strlen(idxBuf), &bw);
+            f_write(&sLogFile, ": size=", 7, &bw);
+            f_write(&sLogFile, sizeBuf, strlen(sizeBuf), &bw);
+            f_write(&sLogFile, " startCl=", 9, &bw);
+            f_write(&sLogFile, startBuf, strlen(startBuf), &bw);
+            f_write(&sLogFile, "\n", 1, &bw);
+        }
+        f_write(&sLogFile, "----------------------\n", 23, &bw);
+        f_close(&sLogFile);
+    }
+}
+
+[[gnu::section(".ewram")]] bool gpoClusterFileOffset(const GpoHeader& header, u32 cluster, u32* outOffset)
+{
+    u32 totalRomClusters = (header.romSize + header.clusterSize - 1) / header.clusterSize;
+    u32 patchedRomSize = header.patchedRomSize > 0 ? header.patchedRomSize : header.romSize;
+    u32 patchedTotalClusters = (patchedRomSize + header.clusterSize - 1) / header.clusterSize;
+
+    if (cluster >= patchedTotalClusters) return false;
+
+    if (cluster >= totalRomClusters)
+    {
+        u32 patchedRomClusterCount = 0;
+        for (u32 c = 0; c < totalRomClusters; c++)
+            if (c < 8192 && (header.bitmask[c / 32] & (1u << (c % 32))))
+                patchedRomClusterCount++;
+        *outOffset = header.clusterSize * (1u + patchedRomClusterCount + (cluster - totalRomClusters));
+        return true;
+    }
+
+    if (cluster >= 8192 || !(header.bitmask[cluster / 32] & (1u << (cluster % 32))))
+        return false;
+
+    u32 gpoIdx = 0;
+    for (u32 i = 0; i < cluster / 32; i++)
+        gpoIdx += gPopCountTable.PopCount(header.bitmask[i]);
+    gpoIdx += gPopCountTable.PopCount(header.bitmask[cluster / 32] & ((1u << (cluster % 32)) - 1));
+
+    *outOffset = header.clusterSize * (1u + gpoIdx);
+    return true;
+}
+
+[[gnu::section(".ewram")]] bool writePatchToGpo(FIL* gpoFile, const GpoHeader& header, u32 romOffset,
+                                                  const u8* data, u32 dataSize)
+{
+    u32 startCluster = romOffset / header.clusterSize;
+    u32 endCluster   = (romOffset + dataSize - 1) / header.clusterSize;
+    for (u32 c = startCluster; c <= endCluster; c++)
+    {
+        u32 clusterStartOffset = c * header.clusterSize;
+        u32 clusterEndOffset   = clusterStartOffset + header.clusterSize;
+        u32 patchStart = romOffset > clusterStartOffset ? romOffset : clusterStartOffset;
+        u32 patchEnd   = (romOffset + dataSize) < clusterEndOffset ? (romOffset + dataSize) : clusterEndOffset;
+        if (patchStart >= patchEnd) continue;
+
+        u32 gpoClusterOffset;
+        if (!gpoClusterFileOffset(header, c, &gpoClusterOffset)) continue;
+
+        u32 targetFileOffset = gpoClusterOffset + (patchStart - clusterStartOffset);
+        UINT bw;
+        if (f_lseek(gpoFile, targetFileOffset) != FR_OK) return false;
+        if (f_write(gpoFile, data + (patchStart - romOffset), patchEnd - patchStart, &bw) != FR_OK
+            || bw != (patchEnd - patchStart)) return false;
+    }
+    return true;
+}
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static u8 sTempBuf[4096];
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static FIL sVerifyFile;
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static FIL sRomFile;
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static FIL sIpsFile;
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static FIL sWriteGpoFile;
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static GpoHeader sVerifyHeader;
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static GpoHeader sCreateHeader;
+
+[[gnu::section(".ewram")]] bool verifyGpo(const char* gpoPath, u32 romSize, u32 patchSize,
+                                            u32 patchTimestamp, u8 patchKind, u32 clusterSize)
+{
+    if (f_open(&sVerifyFile, gpoPath, FA_READ | FA_OPEN_EXISTING) != FR_OK)
+        return false;
+
+    UINT br;
+    if (f_read(&sVerifyFile, &sVerifyHeader, sizeof(sVerifyHeader), &br) != FR_OK || br != sizeof(sVerifyHeader))
+    {
+        f_close(&sVerifyFile);
+        return false;
+    }
+
+    if (memcmp(sVerifyHeader.magic, GPO_MAGIC, 4) != 0)        { f_close(&sVerifyFile); return false; }
+    if (sVerifyHeader.romSize        != romSize)               { f_close(&sVerifyFile); return false; }
+    if (sVerifyHeader.patchSize      != patchSize)              { f_close(&sVerifyFile); return false; }
+    if (sVerifyHeader.patchTimestamp != patchTimestamp)         { f_close(&sVerifyFile); return false; }
+    if (sVerifyHeader.patchKind      != patchKind)              { f_close(&sVerifyFile); return false; }
+    if (sVerifyHeader.clusterSize    != clusterSize)            { f_close(&sVerifyFile); return false; }
+
+    u32 totalRomClusters = (romSize + clusterSize - 1) / clusterSize;
+    u32 P_rom = 0;
+    for (u32 c = 0; c < totalRomClusters; c++)
+        if (c < 8192 && (sVerifyHeader.bitmask[c / 32] & (1u << (c % 32))))
+            P_rom++;
+
+    u32 pRS = sVerifyHeader.patchedRomSize > 0 ? sVerifyHeader.patchedRomSize : romSize;
+    u32 patchedTotalClusters = (pRS + clusterSize - 1) / clusterSize;
+    u32 E = patchedTotalClusters > totalRomClusters ? patchedTotalClusters - totalRomClusters : 0;
+
+    u32 expectedSize = (1 + P_rom + E) * clusterSize;
+    bool sizeOk = f_size(&sVerifyFile) >= expectedSize;
+    f_close(&sVerifyFile);
+    return sizeOk;
+}
+
+[[gnu::section(".ewram")]] bool copyRangeAClusters(FIL* gpoFile, FIL* romFile, const GpoHeader& header)
+{
+    u32 totalRomClusters = (header.romSize + header.clusterSize - 1) / header.clusterSize;
+    u32 patchedRomSize = header.patchedRomSize > 0 ? header.patchedRomSize : header.romSize;
+    u32 patchedTotalClusters = (patchedRomSize + header.clusterSize - 1) / header.clusterSize;
+    u32 rangeALimit = totalRomClusters < patchedTotalClusters ? totalRomClusters : patchedTotalClusters;
+
+    for (u32 c = 0; c < rangeALimit; c++)
+    {
+        if (c >= 8192 || !(header.bitmask[c / 32] & (1u << (c % 32))))
+            continue;
+
+        if (f_lseek(romFile, (FSIZE_t)c * header.clusterSize) != FR_OK)
+            return false;
+
+        u32 remaining = header.clusterSize;
+        while (remaining > 0)
+        {
+            u32 chunk = remaining > sizeof(sTempBuf) ? (u32)sizeof(sTempBuf) : remaining;
+            UINT br, bw;
+            memset(sTempBuf, 0xFF, chunk);
+            if (f_read(romFile, sTempBuf, chunk, &br) != FR_OK)
+                return false;
+            if (f_write(gpoFile, sTempBuf, chunk, &bw) != FR_OK || bw != chunk)
+                return false;
+            remaining -= chunk;
+        }
+    }
+    return true;
+}
+
+[[gnu::section(".ewram")]] bool writeRangeBExtensionClusters(FIL* gpoFile, const GpoHeader& header)
+{
+    u32 totalRomClusters = (header.romSize + header.clusterSize - 1) / header.clusterSize;
+    u32 patchedRomSize = header.patchedRomSize > 0 ? header.patchedRomSize : header.romSize;
+    u32 patchedTotalClusters = (patchedRomSize + header.clusterSize - 1) / header.clusterSize;
+
+    if (patchedTotalClusters <= totalRomClusters) return true;
+
+    memset(sTempBuf, 0xFF, sizeof(sTempBuf));
+    for (u32 c = totalRomClusters; c < patchedTotalClusters; c++)
+    {
+        u32 remaining = header.clusterSize;
+        while (remaining > 0)
+        {
+            u32 chunk = remaining > sizeof(sTempBuf) ? (u32)sizeof(sTempBuf) : remaining;
+            UINT bw;
+            if (f_write(gpoFile, sTempBuf, chunk, &bw) != FR_OK || bw != chunk)
+                return false;
+            remaining -= chunk;
+        }
+    }
+    return true;
+}
+
+[[gnu::section(".ewram")]] static bool writeRleToGpo(FIL* gpoFile, const GpoHeader& header, u32 romOffset,
+                                                        u8 val, u32 count)
+{
+    u32 startCluster = romOffset / header.clusterSize;
+    u32 endCluster   = (romOffset + count - 1) / header.clusterSize;
+    for (u32 c = startCluster; c <= endCluster; c++)
+    {
+        u32 clusterStartOffset = c * header.clusterSize;
+        u32 clusterEndOffset   = clusterStartOffset + header.clusterSize;
+        u32 patchStart = romOffset > clusterStartOffset ? romOffset : clusterStartOffset;
+        u32 patchEnd   = (romOffset + count) < clusterEndOffset ? (romOffset + count) : clusterEndOffset;
+        if (patchStart >= patchEnd) continue;
+
+        u32 gpoClusterOffset;
+        if (!gpoClusterFileOffset(header, c, &gpoClusterOffset)) continue;
+
+        u32 targetFileOffset = gpoClusterOffset + (patchStart - clusterStartOffset);
+        UINT bw;
+        if (f_lseek(gpoFile, targetFileOffset) != FR_OK) return false;
+
+        u32 writeLen = patchEnd - patchStart;
+        u32 fillSize = sizeof(sTempBuf) < header.clusterSize ? sizeof(sTempBuf) : header.clusterSize;
+        memset(sTempBuf, val, fillSize);
+        u32 remaining = writeLen;
+        while (remaining > 0)
+        {
+            u32 chunk = remaining > sizeof(sTempBuf) ? (u32)sizeof(sTempBuf) : remaining;
+            if (f_write(gpoFile, sTempBuf, chunk, &bw) != FR_OK || bw != chunk) return false;
+            remaining -= chunk;
+        }
+    }
+    return true;
+}
+
+[[gnu::section(".ewram")]] bool createGpoFromIps(const char* romPath, const char* ipsPath, const char* gpoPath,
+                                                    u32 romSize, u32 ipsSize, u32 ipsTime, u32 clusterSize)
+{
+    if (clusterSize < sizeof(GpoHeader)) return false;
+
+    if (f_open(&sRomFile,      romPath, FA_READ  | FA_OPEN_EXISTING) != FR_OK) return false;
+    if (f_open(&sIpsFile,      ipsPath, FA_READ  | FA_OPEN_EXISTING) != FR_OK) { f_close(&sRomFile); return false; }
+    if (f_open(&sWriteGpoFile, gpoPath, FA_WRITE | FA_CREATE_ALWAYS) != FR_OK) { f_close(&sRomFile); f_close(&sIpsFile); return false; }
+
+    auto cleanupAndAbort = [&]() -> bool {
+        f_close(&sRomFile);
+        f_close(&sIpsFile);
+        f_close(&sWriteGpoFile);
+        f_unlink(gpoPath);
+        return false;
+    };
+
+    // Write placeholder magic; will be promoted to GPO_MAGIC only on final committed rewrite.
+    // If power is lost mid-creation, verifyGpo rejects "GPOT" and triggers a clean rebuild next boot.
+    memcpy(sCreateHeader.magic, GPO_MAGIC_PLACEHOLDER, 4);
+    sCreateHeader.romSize = romSize;
+    sCreateHeader.patchedRomSize = 0;  // filled in after Pass 1
+    sCreateHeader.patchSize = ipsSize;
+    sCreateHeader.patchTimestamp = ipsTime;
+    sCreateHeader.patchKind = (u8)GpoPatchKind::Ips;
+    sCreateHeader.clusterSize = clusterSize;
+    memset(sCreateHeader.bitmask, 0, sizeof(sCreateHeader.bitmask));
+
+    char ipsHeader[5];
+    UINT br;
+    if (f_read(&sIpsFile, ipsHeader, 5, &br) != FR_OK || br != 5 || memcmp(ipsHeader, "PATCH", 5) != 0)
+        return cleanupAndAbort();
+
+    u32 maxHunkExtent = 0;
+    bool eofReached = false;
+
+    // Pass 1: scan IPS to identify patched clusters and find max hunk extent
+    while (true)
+    {
+        u8 offsetBuf[3];
+        if (f_read(&sIpsFile, offsetBuf, 3, &br) != FR_OK || br != 3) break;
+        u32 offset = ((u32)offsetBuf[0] << 16) | ((u32)offsetBuf[1] << 8) | offsetBuf[2];
+
+        // SNESTool EOF ambiguity fix: treat 0x454F46 as EOF only if <= 3 bytes remain.
+        // A real hunk at this offset would need at least 2 size bytes + 1 data byte.
+        if (offset == 0x454F46 && (ipsSize - (u32)f_tell(&sIpsFile)) <= 3)
+        {
+            eofReached = true;
+            break;
+        }
+
+        u8 sizeBuf[2];
+        if (f_read(&sIpsFile, sizeBuf, 2, &br) != FR_OK || br != 2) break;
+        u32 size = ((u32)sizeBuf[0] << 8) | sizeBuf[1];
+
+        if (size > 0)
+        {
+            if (offset + size > maxHunkExtent) maxHunkExtent = offset + size;
+
+            u32 startBlock = offset / 4096;
+            u32 endBlock   = (offset + size - 1) / 4096;
+            u32 blocksPerCluster = clusterSize / 4096;
+            if (blocksPerCluster == 0) blocksPerCluster = 1;
+            for (u32 b = startBlock; b <= endBlock; b++)
+            {
+                u32 c = b / blocksPerCluster;
+                if (c < 8192)
+                    sCreateHeader.bitmask[c / 32] |= (1u << (c % 32));
+            }
+            if (f_lseek(&sIpsFile, f_tell(&sIpsFile) + size) != FR_OK)
+                return cleanupAndAbort();
+        }
+        else
+        {
+            u8 countBuf[2];
+            if (f_read(&sIpsFile, countBuf, 2, &br) != FR_OK || br != 2) break;
+            u32 count = ((u32)countBuf[0] << 8) | countBuf[1];
+            if (count == 0) return cleanupAndAbort();  // corrupt RLE: infinite loop guard
+
+            u8 val;
+            if (f_read(&sIpsFile, &val, 1, &br) != FR_OK || br != 1) break;
+
+            if (offset + count > maxHunkExtent) maxHunkExtent = offset + count;
+
+            u32 startBlock = offset / 4096;
+            u32 endBlock   = (offset + count - 1) / 4096;
+            u32 blocksPerCluster = clusterSize / 4096;
+            if (blocksPerCluster == 0) blocksPerCluster = 1;
+            for (u32 b = startBlock; b <= endBlock; b++)
+            {
+                u32 c = b / blocksPerCluster;
+                if (c < 8192)
+                    sCreateHeader.bitmask[c / 32] |= (1u << (c % 32));
+            }
+        }
+    }
+
+    if (!eofReached) return cleanupAndAbort();
+
+    // Truncate field: IPS may have 3 optional bytes after EOF marker specifying new ROM size
+    u32 truncateValue = 0;
+    {
+        FSIZE_t remaining = ipsSize - f_tell(&sIpsFile);
+        if (remaining == 3)
+        {
+            u8 truncBuf[3];
+            if (f_read(&sIpsFile, truncBuf, 3, &br) == FR_OK && br == 3)
+                truncateValue = ((u32)truncBuf[0] << 16) | ((u32)truncBuf[1] << 8) | truncBuf[2];
+        }
+    }
+
+    // Effective ROM size after patch
+    u32 patchedRomSize = truncateValue > 0
+        ? truncateValue
+        : (maxHunkExtent > romSize ? maxHunkExtent : romSize);
+    sCreateHeader.patchedRomSize = patchedRomSize;
+
+    u32 totalRomClusters     = (romSize        + clusterSize - 1) / clusterSize;
+    u32 patchedTotalClusters = (patchedRomSize + clusterSize - 1) / clusterSize;
+
+    // Clear bitmask bits outside [0, min(totalRomClusters, patchedTotalClusters)).
+    // Extension clusters do not use the bitmask; truncated-away clusters must not either.
+    u32 cleanBound = totalRomClusters < patchedTotalClusters
+        ? totalRomClusters : patchedTotalClusters;
+    for (u32 c = cleanBound; c < 8192; c++)
+        sCreateHeader.bitmask[c / 32] &= ~(1u << (c % 32));
+
+    // Write placeholder header (GPOT magic); promoted to GPO2 only at the end
+    UINT bw;
+    if (f_write(&sWriteGpoFile, &sCreateHeader, sizeof(sCreateHeader), &bw) != FR_OK
+        || bw != sizeof(sCreateHeader))
+        return cleanupAndAbort();
+
+    memset(sTempBuf, 0, sizeof(sTempBuf));
+    u32 paddingBytes = clusterSize - sizeof(sCreateHeader);
+    while (paddingBytes > 0)
+    {
+        u32 chunk = paddingBytes > sizeof(sTempBuf) ? (u32)sizeof(sTempBuf) : paddingBytes;
+        if (f_write(&sWriteGpoFile, sTempBuf, chunk, &bw) != FR_OK || bw != chunk)
+            return cleanupAndAbort();
+        paddingBytes -= chunk;
+    }
+
+    if (!copyRangeAClusters(&sWriteGpoFile, &sRomFile, sCreateHeader)) return cleanupAndAbort();
+    if (!writeRangeBExtensionClusters(&sWriteGpoFile, sCreateHeader)) return cleanupAndAbort();
+
+    // Pass 2: Apply IPS patches to GPO file
+    if (f_lseek(&sIpsFile, 5) != FR_OK) return cleanupAndAbort();
+
+    bool pass2Eof = false;
+    while (true)
+    {
+        u8 offsetBuf[3];
+        if (f_read(&sIpsFile, offsetBuf, 3, &br) != FR_OK || br != 3) break;
+        u32 offset = ((u32)offsetBuf[0] << 16) | ((u32)offsetBuf[1] << 8) | offsetBuf[2];
+
+        if (offset == 0x454F46 && (ipsSize - (u32)f_tell(&sIpsFile)) <= 3)
+        {
+            pass2Eof = true;
+            break;
+        }
+
+        u8 sizeBuf[2];
+        if (f_read(&sIpsFile, sizeBuf, 2, &br) != FR_OK || br != 2) break;
+        u32 size = ((u32)sizeBuf[0] << 8) | sizeBuf[1];
+
+        if (size > 0)
+        {
+            u32 remaining = size;
+            u32 currentOffset = offset;
+            while (remaining > 0)
+            {
+                u32 chunk = remaining > sizeof(sTempBuf) ? (u32)sizeof(sTempBuf) : remaining;
+                if (f_read(&sIpsFile, sTempBuf, chunk, &br) != FR_OK || br != chunk)
+                    return cleanupAndAbort();
+                if (!writePatchToGpo(&sWriteGpoFile, sCreateHeader, currentOffset, sTempBuf, chunk))
+                    return cleanupAndAbort();
+                currentOffset += chunk;
+                remaining -= chunk;
+            }
+        }
+        else
+        {
+            u8 countBuf[2];
+            if (f_read(&sIpsFile, countBuf, 2, &br) != FR_OK || br != 2) break;
+            u32 count = ((u32)countBuf[0] << 8) | countBuf[1];
+            if (count == 0) return cleanupAndAbort();
+
+            u8 val;
+            if (f_read(&sIpsFile, &val, 1, &br) != FR_OK || br != 1) break;
+
+            if (!writeRleToGpo(&sWriteGpoFile, sCreateHeader, offset, val, count))
+                return cleanupAndAbort();
+        }
+    }
+
+    // A truncated IPS (no EOF marker in Pass 2) must not commit the GPO
+    if (!pass2Eof) return cleanupAndAbort();
+
+    // Final header commit: promote placeholder magic to GPO_MAGIC
+    memcpy(sCreateHeader.magic, GPO_MAGIC, 4);
+    if (f_lseek(&sWriteGpoFile, 0) != FR_OK) return cleanupAndAbort();
+    if (f_write(&sWriteGpoFile, &sCreateHeader, sizeof(sCreateHeader), &bw) != FR_OK
+        || bw != sizeof(sCreateHeader))
+        return cleanupAndAbort();
+
+    f_close(&sRomFile);
+    f_close(&sIpsFile);
+    f_close(&sWriteGpoFile);
+    return true;
+}

--- a/code/core/arm9/source/Patches/GpoBuilder.h
+++ b/code/core/arm9/source/Patches/GpoBuilder.h
@@ -1,0 +1,24 @@
+#pragma once
+#include "common.h"
+#include "Fat/ff.h"
+#include "GpoPatcher.h"
+
+void gpo_getPath(const char* romPath, char* outPath, const char* ext);
+void log_debug(const char* romPath, const char* msg, u32 val1 = 0xFFFFFFFF, u32 val2 = 0xFFFFFFFF);
+void log_table(const char* romPath, const DWORD* tbl);
+
+// True if ROM cluster `cluster` is stored in the GPO file (patched or extension cluster);
+// *outOffset is then its byte offset within the GPO file. False means: read this cluster
+// unmodified from the original ROM at `cluster * header.clusterSize` instead.
+bool gpoClusterFileOffset(const GpoHeader& header, u32 cluster, u32* outOffset);
+
+bool writePatchToGpo(FIL* gpoFile, const GpoHeader& header, u32 romOffset, const u8* data, u32 dataSize);
+
+bool verifyGpo(const char* gpoPath, u32 romSize, u32 patchSize, u32 patchTimestamp,
+               u8 patchKind, u32 clusterSize);
+
+bool copyRangeAClusters(FIL* gpoFile, FIL* romFile, const GpoHeader& header);
+bool writeRangeBExtensionClusters(FIL* gpoFile, const GpoHeader& header);
+
+bool createGpoFromIps(const char* romPath, const char* ipsPath, const char* gpoPath,
+                       u32 romSize, u32 ipsSize, u32 ipsTime, u32 clusterSize);

--- a/code/core/arm9/source/Patches/GpoPatcher.cpp
+++ b/code/core/arm9/source/Patches/GpoPatcher.cpp
@@ -1,0 +1,713 @@
+#include "GpoPatcher.h"
+#include "PopCountTable.h"
+#include "MemoryEmulator/RomDefs.h"
+#include <string.h>
+#include <stdlib.h>
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+u32 gGpoBitmask[8192 / 32];
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+FIL gGpoFile;
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static DWORD sGpoClusterTable[512];
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static DWORD sMergedClusterTable[2048];
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static u8 sTempBuf[4096];
+
+// Static allocations in EWRAM BSS to prevent stack overflow in DTCM
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static FIL sVerifyFile;
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static FIL sRomFile;
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static FIL sIpsFile;
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static FIL sWriteGpoFile;
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static FIL sLogFile;
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static FILINFO sFnoIps;
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static FILINFO sFnoRom;
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static char sIpsPath[256];
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static char sGpoPath[256];
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static char sLogPath[256];
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static GpoHeader sVerifyHeader;
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static GpoHeader sCreateHeader;
+
+extern FIL gFile; // Holds the GBA ROM file object and its cltbl
+
+[[gnu::section(".ewram")]] static void gpo_getPath(const char* romPath, char* outPath, const char* ext)
+{
+    strcpy(outPath, romPath);
+    char* dot = strrchr(outPath, '.');
+    if (dot)
+    {
+        strcpy(dot, ext);
+    }
+    else
+    {
+        strcat(outPath, ext);
+    }
+}
+
+[[gnu::section(".ewram")]] static void u32_to_str(u32 val, char* buf)
+{
+    char temp[16];
+    int i = 0;
+    if (val == 0)
+    {
+        buf[0] = '0';
+        buf[1] = '\0';
+        return;
+    }
+    while (val > 0)
+    {
+        temp[i++] = '0' + (val % 10);
+        val /= 10;
+    }
+    for (int j = 0; j < i; j++)
+    {
+        buf[j] = temp[i - 1 - j];
+    }
+    buf[i] = '\0';
+}
+
+[[gnu::section(".ewram")]] static void log_debug(const char* romPath, const char* msg, u32 val1 = 0xFFFFFFFF, u32 val2 = 0xFFFFFFFF)
+{
+    gpo_getPath(romPath, sLogPath, "_gpo.log");
+    if (f_open(&sLogFile, sLogPath, FA_WRITE | FA_OPEN_ALWAYS) == FR_OK)
+    {
+        f_lseek(&sLogFile, f_size(&sLogFile));
+        UINT bw;
+        f_write(&sLogFile, msg, strlen(msg), &bw);
+        if (val1 != 0xFFFFFFFF)
+        {
+            char valBuf[16];
+            u32_to_str(val1, valBuf);
+            f_write(&sLogFile, " val1: ", 7, &bw);
+            f_write(&sLogFile, valBuf, strlen(valBuf), &bw);
+        }
+        if (val2 != 0xFFFFFFFF)
+        {
+            char valBuf[16];
+            u32_to_str(val2, valBuf);
+            f_write(&sLogFile, " val2: ", 7, &bw);
+            f_write(&sLogFile, valBuf, strlen(valBuf), &bw);
+        }
+        f_write(&sLogFile, "\n", 1, &bw);
+        f_close(&sLogFile);
+    }
+}
+
+[[gnu::section(".ewram")]] static void log_table(const char* romPath, const DWORD* tbl)
+{
+    gpo_getPath(romPath, sLogPath, "_gpo.log");
+    if (f_open(&sLogFile, sLogPath, FA_WRITE | FA_OPEN_ALWAYS) == FR_OK)
+    {
+        f_lseek(&sLogFile, f_size(&sLogFile));
+        UINT bw;
+        f_write(&sLogFile, "--- Merged Linkmap ---\n", 23, &bw);
+        u32 totalDwords = tbl[0];
+        char szBuf[16];
+        u32_to_str(totalDwords, szBuf);
+        f_write(&sLogFile, "Total DWORDs: ", 14, &bw);
+        f_write(&sLogFile, szBuf, strlen(szBuf), &bw);
+        f_write(&sLogFile, "\n", 1, &bw);
+        
+        for (u32 i = 1; i < totalDwords; i += 2)
+        {
+            char idxBuf[16], sizeBuf[16], startBuf[16];
+            u32_to_str(i / 2, idxBuf);
+            u32_to_str(tbl[i], sizeBuf);
+            u32_to_str(tbl[i+1], startBuf);
+            
+            f_write(&sLogFile, " Frag ", 6, &bw);
+            f_write(&sLogFile, idxBuf, strlen(idxBuf), &bw);
+            f_write(&sLogFile, ": size=", 7, &bw);
+            f_write(&sLogFile, sizeBuf, strlen(sizeBuf), &bw);
+            f_write(&sLogFile, " startCl=", 9, &bw);
+            f_write(&sLogFile, startBuf, strlen(startBuf), &bw);
+            f_write(&sLogFile, "\n", 1, &bw);
+        }
+        f_write(&sLogFile, "----------------------\n", 23, &bw);
+        f_close(&sLogFile);
+    }
+}
+
+[[gnu::section(".ewram")]] static bool verifyGpo(const char* gpoPath, u32 romSize, u32 ipsSize, u32 ipsTime, u32 clusterSize)
+{
+    if (f_open(&sVerifyFile, gpoPath, FA_READ | FA_OPEN_EXISTING) != FR_OK)
+        return false;
+
+    UINT br;
+    if (f_read(&sVerifyFile, &sVerifyHeader, sizeof(sVerifyHeader), &br) != FR_OK || br != sizeof(sVerifyHeader))
+    {
+        f_close(&sVerifyFile);
+        return false;
+    }
+    f_close(&sVerifyFile);
+
+    if (memcmp(sVerifyHeader.magic, GPO_MAGIC, 4) != 0)
+        return false;
+    if (sVerifyHeader.romSize != romSize)
+        return false;
+    if (sVerifyHeader.ipsSize != ipsSize)
+        return false;
+    if (sVerifyHeader.ipsTimestamp != ipsTime)
+        return false;
+    if (sVerifyHeader.clusterSize != clusterSize)
+        return false;
+
+    return true;
+}
+
+[[gnu::section(".ewram")]] static bool createGpo(const char* romPath, const char* ipsPath, const char* gpoPath, u32 romSize, u32 ipsSize, u32 ipsTime, u32 clusterSize)
+{
+    if (f_open(&sRomFile, romPath, FA_READ | FA_OPEN_EXISTING) != FR_OK) return false;
+    if (f_open(&sIpsFile, ipsPath, FA_READ | FA_OPEN_EXISTING) != FR_OK) { f_close(&sRomFile); return false; }
+    if (f_open(&sWriteGpoFile, gpoPath, FA_WRITE | FA_CREATE_ALWAYS) != FR_OK) { f_close(&sRomFile); f_close(&sIpsFile); return false; }
+
+    memcpy(sCreateHeader.magic, GPO_MAGIC, 4);
+    sCreateHeader.romSize = romSize;
+    sCreateHeader.ipsSize = ipsSize;
+    sCreateHeader.ipsTimestamp = ipsTime;
+    sCreateHeader.clusterSize = clusterSize;
+    memset(sCreateHeader.bitmask, 0, sizeof(sCreateHeader.bitmask));
+
+    char ipsHeader[5];
+    UINT br;
+    if (f_read(&sIpsFile, ipsHeader, 5, &br) != FR_OK || br != 5 || memcmp(ipsHeader, "PATCH", 5) != 0)
+    {
+        f_close(&sRomFile); f_close(&sIpsFile); f_close(&sWriteGpoFile);
+        return false;
+    }
+
+    u32 blocksPerCluster = clusterSize / 4096;
+    if (blocksPerCluster == 0) blocksPerCluster = 1;
+
+    // Scan IPS to identify patched clusters
+    while (true)
+    {
+        u8 offsetBuf[3];
+        if (f_read(&sIpsFile, offsetBuf, 3, &br) != FR_OK || br != 3) break;
+        u32 offset = (offsetBuf[0] << 16) | (offsetBuf[1] << 8) | offsetBuf[2];
+        if (offset == 0x454F46)
+            break;
+
+        u8 sizeBuf[2];
+        if (f_read(&sIpsFile, sizeBuf, 2, &br) != FR_OK || br != 2) break;
+        u32 size = (sizeBuf[0] << 8) | sizeBuf[1];
+
+        if (size > 0)
+        {
+            u32 startBlock = offset / 4096;
+            u32 endBlock = (offset + size - 1) / 4096;
+            for (u32 b = startBlock; b <= endBlock; b++)
+            {
+                u32 c = b / blocksPerCluster;
+                if (c < 8192)
+                    sCreateHeader.bitmask[c / 32] |= (1u << (c % 32));
+            }
+            if (f_lseek(&sIpsFile, f_tell(&sIpsFile) + size) != FR_OK)
+            {
+                f_close(&sRomFile); f_close(&sIpsFile); f_close(&sWriteGpoFile);
+                return false;
+            }
+        }
+        else
+        {
+            u8 countBuf[2];
+            if (f_read(&sIpsFile, countBuf, 2, &br) != FR_OK || br != 2) break;
+            u32 count = (countBuf[0] << 8) | countBuf[1];
+            
+            u8 val;
+            if (f_read(&sIpsFile, &val, 1, &br) != FR_OK || br != 1) break;
+
+            u32 startBlock = offset / 4096;
+            u32 endBlock = (offset + count - 1) / 4096;
+            for (u32 b = startBlock; b <= endBlock; b++)
+            {
+                u32 c = b / blocksPerCluster;
+                if (c < 8192)
+                    sCreateHeader.bitmask[c / 32] |= (1u << (c % 32));
+            }
+        }
+    }
+
+    // Write header
+    UINT bw;
+    f_write(&sWriteGpoFile, &sCreateHeader, sizeof(sCreateHeader), &bw);
+
+    // Pad header to clusterSize using sTempBuf (already EWRAM static)
+    memset(sTempBuf, 0, sizeof(sTempBuf));
+    u32 paddingBytes = clusterSize - sizeof(sCreateHeader);
+    while (paddingBytes > 0)
+    {
+        u32 chunk = paddingBytes > sizeof(sTempBuf) ? sizeof(sTempBuf) : paddingBytes;
+        f_write(&sWriteGpoFile, sTempBuf, chunk, &bw);
+        paddingBytes -= chunk;
+    }
+
+    // Write original GBA ROM clusters for patched clusters
+    u32 totalClusters = (romSize + clusterSize - 1) / clusterSize;
+    for (u32 c = 0; c < totalClusters; c++)
+    {
+        if (sCreateHeader.bitmask[c / 32] & (1u << (c % 32)))
+        {
+            f_lseek(&sRomFile, c * clusterSize);
+            u32 remaining = clusterSize;
+            while (remaining > 0)
+            {
+                u32 chunk = remaining > 4096 ? 4096 : remaining;
+                memset(sTempBuf, 0xFF, chunk);
+                f_read(&sRomFile, sTempBuf, chunk, &br);
+                f_write(&sWriteGpoFile, sTempBuf, chunk, &bw);
+                remaining -= chunk;
+            }
+        }
+    }
+
+    // Apply patches to GPO
+    f_lseek(&sIpsFile, 5);
+
+    auto writePatchToGpo = [&](u32 romOffset, const u8* data, u32 dataSize) {
+        u32 startCluster = romOffset / clusterSize;
+        u32 endCluster = (romOffset + dataSize - 1) / clusterSize;
+        for (u32 c = startCluster; c <= endCluster; c++)
+        {
+            if (c >= 8192) continue;
+            if (!(sCreateHeader.bitmask[c / 32] & (1u << (c % 32)))) continue;
+
+            u32 patchedClusterIndex = 0;
+            for (u32 i = 0; i < c / 32; i++)
+                patchedClusterIndex += gPopCountTable.PopCount(sCreateHeader.bitmask[i]);
+            patchedClusterIndex += gPopCountTable.PopCount(sCreateHeader.bitmask[c / 32] & ((1u << (c % 32)) - 1));
+            
+            u32 clusterStartOffset = c * clusterSize;
+            u32 clusterEndOffset = clusterStartOffset + clusterSize;
+            
+            u32 patchStart = romOffset > clusterStartOffset ? romOffset : clusterStartOffset;
+            u32 patchEnd = (romOffset + dataSize) < clusterEndOffset ? (romOffset + dataSize) : clusterEndOffset;
+            
+            if (patchStart < patchEnd)
+            {
+                u32 targetFileOffset = clusterSize + patchedClusterIndex * clusterSize + (patchStart - clusterStartOffset);
+                f_lseek(&sWriteGpoFile, targetFileOffset);
+                f_write(&sWriteGpoFile, data + (patchStart - romOffset), patchEnd - patchStart, &bw);
+            }
+        }
+    };
+
+    auto writeRleToGpo = [&](u32 romOffset, u8 val, u32 count) {
+        u32 startCluster = romOffset / clusterSize;
+        u32 endCluster = (romOffset + count - 1) / clusterSize;
+        for (u32 c = startCluster; c <= endCluster; c++)
+        {
+            if (c >= 8192) continue;
+            if (!(sCreateHeader.bitmask[c / 32] & (1u << (c % 32)))) continue;
+
+            u32 patchedClusterIndex = 0;
+            for (u32 i = 0; i < c / 32; i++)
+                patchedClusterIndex += gPopCountTable.PopCount(sCreateHeader.bitmask[i]);
+            patchedClusterIndex += gPopCountTable.PopCount(sCreateHeader.bitmask[c / 32] & ((1u << (c % 32)) - 1));
+            
+            u32 clusterStartOffset = c * clusterSize;
+            u32 clusterEndOffset = clusterStartOffset + clusterSize;
+            
+            u32 patchStart = romOffset > clusterStartOffset ? romOffset : clusterStartOffset;
+            u32 patchEnd = (romOffset + count) < clusterEndOffset ? (romOffset + count) : clusterEndOffset;
+            
+            if (patchStart < patchEnd)
+            {
+                u32 targetFileOffset = clusterSize + patchedClusterIndex * clusterSize + (patchStart - clusterStartOffset);
+                f_lseek(&sWriteGpoFile, targetFileOffset);
+                u32 writeLen = patchEnd - patchStart;
+                
+                u32 remaining = writeLen;
+                memset(sTempBuf, val, clusterSize < 4096 ? clusterSize : 4096);
+                while (remaining > 0)
+                {
+                    u32 chunk = remaining > 4096 ? 4096 : remaining;
+                    f_write(&sWriteGpoFile, sTempBuf, chunk, &bw);
+                    remaining -= chunk;
+                }
+            }
+        }
+    };
+
+    while (true)
+    {
+        u8 offsetBuf[3];
+        if (f_read(&sIpsFile, offsetBuf, 3, &br) != FR_OK || br != 3) break;
+        u32 offset = (offsetBuf[0] << 16) | (offsetBuf[1] << 8) | offsetBuf[2];
+        if (offset == 0x454F46)
+            break;
+
+        u8 sizeBuf[2];
+        if (f_read(&sIpsFile, sizeBuf, 2, &br) != FR_OK || br != 2) break;
+        u32 size = (sizeBuf[0] << 8) | sizeBuf[1];
+
+        if (size > 0)
+        {
+            u32 remaining = size;
+            u32 currentOffset = offset;
+            while (remaining > 0)
+            {
+                u32 chunk = remaining > 4096 ? 4096 : remaining;
+                f_read(&sIpsFile, sTempBuf, chunk, &br);
+                writePatchToGpo(currentOffset, sTempBuf, chunk);
+                currentOffset += chunk;
+                remaining -= chunk;
+            }
+        }
+        else
+        {
+            u8 countBuf[2];
+            if (f_read(&sIpsFile, countBuf, 2, &br) != FR_OK || br != 2) break;
+            u32 count = (countBuf[0] << 8) | countBuf[1];
+            
+            u8 val;
+            f_read(&sIpsFile, &val, 1, &br);
+            
+            writeRleToGpo(offset, val, count);
+        }
+    }
+
+    f_lseek(&sWriteGpoFile, 0);
+    f_write(&sWriteGpoFile, &sCreateHeader, sizeof(sCreateHeader), &bw);
+
+    f_close(&sRomFile);
+    f_close(&sIpsFile);
+    f_close(&sWriteGpoFile);
+    return true;
+}
+
+struct ClmtTracker
+{
+    const DWORD* tbl;
+    DWORD currentLogicalBase;
+    DWORD currentFragSize;
+    DWORD currentFragPhysStart;
+
+    void Init(const DWORD* cltbl)
+    {
+        tbl = cltbl + 1;
+        currentLogicalBase = 0;
+        currentFragSize = *tbl++;
+        currentFragPhysStart = *tbl++;
+    }
+
+    DWORD GetPhysicalCluster(DWORD logicalCluster)
+    {
+        while (currentFragSize > 0 && logicalCluster >= currentLogicalBase + currentFragSize)
+        {
+            currentLogicalBase += currentFragSize;
+            currentFragSize = *tbl++;
+            currentFragPhysStart = *tbl++;
+        }
+        if (currentFragSize == 0) return 0; // EOF / Error
+        
+        return currentFragPhysStart + (logicalCluster - currentLogicalBase);
+    }
+};
+
+[[gnu::section(".ewram")]] static bool mergeClusterMaps(u32 romSize, u32 clusterSize)
+{
+    u32 totalClusters = (romSize + clusterSize - 1) / clusterSize;
+    
+    DWORD* dest = sMergedClusterTable + 1;
+    u32 tableLimit = 2048 - 2;
+    
+    u32 fragmentCount = 0;
+    u32 currentFragSize = 0;
+    DWORD currentFragStartPhys = 0;
+    
+    u32 patchedClusterIndex = 0;
+    
+    ClmtTracker romTracker;
+    romTracker.Init(gFile.cltbl);
+    
+    ClmtTracker gpoTracker;
+    gpoTracker.Init(sGpoClusterTable);
+    
+    for (u32 c = 0; c < totalClusters; c++)
+    {
+        bool isPatched = c < 8192 && (gGpoBitmask[c / 32] & (1u << (c % 32)));
+        
+        DWORD physCl = 0;
+        if (isPatched)
+        {
+            physCl = gpoTracker.GetPhysicalCluster(1 + patchedClusterIndex);
+            patchedClusterIndex++;
+        }
+        else
+        {
+            physCl = romTracker.GetPhysicalCluster(c);
+        }
+        
+        if (physCl == 0)
+        {
+            return false;
+        }
+        
+        if (currentFragSize == 0)
+        {
+            currentFragSize = 1;
+            currentFragStartPhys = physCl;
+        }
+        else if (physCl == currentFragStartPhys + currentFragSize)
+        {
+            currentFragSize++;
+        }
+        else
+        {
+            if ((u32)(dest - sMergedClusterTable) >= tableLimit)
+            {
+                return false;
+            }
+            *dest++ = currentFragSize;
+            *dest++ = currentFragStartPhys;
+            fragmentCount++;
+            
+            currentFragSize = 1;
+            currentFragStartPhys = physCl;
+        }
+    }
+    
+    if (currentFragSize > 0)
+    {
+        if ((u32)(dest - sMergedClusterTable) >= tableLimit)
+        {
+            return false;
+        }
+        *dest++ = currentFragSize;
+        *dest++ = currentFragStartPhys;
+        fragmentCount++;
+    }
+    
+    *dest = 0;
+    sMergedClusterTable[0] = (dest - sMergedClusterTable);
+    return true;
+}
+
+#ifndef NDEBUG
+[[gnu::section(".ewram")]] static void gpo_runUnitTests(void)
+{
+    if (!gLogger) return;
+    gLogger->Log(LogLevel::Debug, "[GPO Test] Running mergeClusterMaps unit tests...\n");
+
+    // Backup original cltbl
+    DWORD* origCltbl = gFile.cltbl;
+
+    // Mock GBA ROM cluster table (representing 1000 clusters contiguously starting at cluster 100)
+    DWORD gbaCltblMock[4];
+    gbaCltblMock[0] = 3;
+    gbaCltblMock[1] = 1000;
+    gbaCltblMock[2] = 100;
+    gbaCltblMock[3] = 0;
+    gFile.cltbl = gbaCltblMock;
+
+    // Mock GPO cluster table (representing 2000 clusters contiguously starting at cluster 5000)
+    sGpoClusterTable[0] = 3;
+    sGpoClusterTable[1] = 2000;
+    sGpoClusterTable[2] = 5000;
+    sGpoClusterTable[3] = 0;
+
+    // Test 1: Merge under limit (200 clusters, alternating)
+    // Alternate every odd cluster
+    memset(gGpoBitmask, 0, sizeof(gGpoBitmask));
+    for (u32 i = 0; i < 200; i++)
+    {
+        if (i % 2 == 1)
+        {
+            gGpoBitmask[i / 32] |= (1u << (i % 32));
+        }
+    }
+    bool res1 = mergeClusterMaps(200 * 4096, 4096);
+    gLogger->Log(LogLevel::Debug, "[GPO Test] Merge under limit (200 clusters, alternating): %s (expected: true)\n", res1 ? "PASS" : "FAIL");
+
+    // Test 2: Merge over limit to trigger overflow
+    // Alternating 1100 clusters produces ~1100 fragments; limit is 1023, so this must overflow.
+    memset(gGpoBitmask, 0, sizeof(gGpoBitmask));
+    for (u32 i = 0; i < 1100; i++)
+    {
+        if (i % 2 == 1)
+        {
+            gGpoBitmask[i / 32] |= (1u << (i % 32));
+        }
+    }
+    bool res2 = mergeClusterMaps(1100 * 4096, 4096);
+    gLogger->Log(LogLevel::Debug, "[GPO Test] Merge over limit (1100 clusters, alternating): %s (expected: false)\n", !res2 ? "PASS" : "FAIL");
+
+    // Restore original state
+    gFile.cltbl = origCltbl;
+    memset(gGpoBitmask, 0, sizeof(gGpoBitmask));
+}
+#endif
+
+extern "C" [[gnu::section(".ewram")]] bool gpo_init(const char* romPath)
+{
+    gpo_getPath(romPath, sIpsPath, ".ips");
+
+    if (f_stat(sIpsPath, &sFnoIps) != FR_OK)
+    {
+        return false;
+    }
+
+#ifndef NDEBUG
+    gpo_runUnitTests();
+#endif
+
+    gpo_getPath(romPath, sGpoPath, ".gpo");
+
+#ifndef NDEBUG
+    gpo_getPath(romPath, sLogPath, "_gpo.log");
+    f_unlink(sLogPath);
+    log_debug(romPath, "=== GPO INIT ===");
+#endif
+
+    if (f_stat(romPath, &sFnoRom) != FR_OK)
+    {
+#ifndef NDEBUG
+        log_debug(romPath, "No ROM file found at path:", 0, 0);
+#endif
+        return false;
+    }
+
+    u32 romSize = sFnoRom.fsize;
+    u32 ipsSize = sFnoIps.fsize;
+    u32 ipsTime = sFnoIps.fdate | (sFnoIps.ftime << 16);
+    u32 clusterSize = gFile.obj.fs->csize * 512;
+
+#ifndef NDEBUG
+    log_debug(romPath, "ROM/IPS size loaded:", romSize, ipsSize);
+    log_debug(romPath, "Cluster size of SD card:", clusterSize);
+#endif
+
+    if (!verifyGpo(sGpoPath, romSize, ipsSize, ipsTime, clusterSize))
+    {
+#ifndef NDEBUG
+        log_debug(romPath, "GPO signature mismatch or file missing. Generating GPO patch...");
+#endif
+        if (!createGpo(romPath, sIpsPath, sGpoPath, romSize, ipsSize, ipsTime, clusterSize))
+        {
+#ifndef NDEBUG
+            log_debug(romPath, "createGpo failed!");
+#endif
+            return false;
+        }
+#ifndef NDEBUG
+        log_debug(romPath, "createGpo succeeded!");
+#endif
+    }
+#ifndef NDEBUG
+    else
+    {
+        log_debug(romPath, "Existing GPO verified successfully.");
+    }
+#endif
+
+    if (f_open(&gGpoFile, sGpoPath, FA_READ | FA_OPEN_EXISTING) != FR_OK)
+    {
+#ifndef NDEBUG
+        log_debug(romPath, "f_open gGpoFile failed!");
+#endif
+        return false;
+    }
+
+    UINT br;
+    if (f_read(&gGpoFile, &sVerifyHeader, sizeof(sVerifyHeader), &br) != FR_OK || br != sizeof(sVerifyHeader))
+    {
+#ifndef NDEBUG
+        log_debug(romPath, "f_read GpoHeader failed!");
+#endif
+        f_close(&gGpoFile);
+        return false;
+    }
+
+    memcpy(gGpoBitmask, sVerifyHeader.bitmask, sizeof(gGpoBitmask));
+
+    sGpoClusterTable[0] = sizeof(sGpoClusterTable) / sizeof(DWORD);
+    gGpoFile.cltbl = sGpoClusterTable;
+    if (f_lseek(&gGpoFile, CREATE_LINKMAP) != FR_OK)
+    {
+#ifndef NDEBUG
+        log_debug(romPath, "f_lseek CREATE_LINKMAP failed on gGpoFile!");
+#endif
+        f_close(&gGpoFile);
+        return false;
+    }
+
+#ifndef NDEBUG
+    log_debug(romPath, "sGpoClusterTable[0] size after CREATE_LINKMAP:", sGpoClusterTable[0]);
+#endif
+
+    if (!mergeClusterMaps(romSize, clusterSize))
+    {
+#ifndef NDEBUG
+        log_debug(romPath, "mergeClusterMaps failed!");
+#endif
+        f_close(&gGpoFile);
+        return false;
+    }
+
+    gFile.cltbl = sMergedClusterTable;
+
+#ifndef NDEBUG
+    log_debug(romPath, "mergeClusterMaps succeeded!");
+    log_table(romPath, sMergedClusterTable);
+    log_debug(romPath, "GPO Patch initialized successfully!");
+#endif
+
+    return true;
+}
+
+// After the linear chunk is loaded via f_read, FatFS serves cluster 0 from gFile.obj.sclust
+// (bypassing the merged CLMT) because fptr==0 triggers the sclust fallback.  Any IPS patch
+// that touches cluster 0 is therefore not applied.  This function corrects that by reading
+// every patched cluster that falls inside the linear window directly from gGpoFile, whose
+// own CLMT (sGpoClusterTable) has no fptr==0 ambiguity for these seeks.
+extern "C" [[gnu::section(".ewram")]] void gpo_patchLinearChunk(u32 clusterSize, u32 linearChunkSize)
+{
+    u32 maxLinearCluster = linearChunkSize / clusterSize;
+    u32 limit = maxLinearCluster < 8192u ? maxLinearCluster : 8192u;
+    u32 patchedIndex = 0;
+
+    for (u32 c = 0; c < limit; c++)
+    {
+        if (gGpoBitmask[c / 32] & (1u << (c % 32)))
+        {
+            // GPO file layout: one header cluster (padded), then patched ROM clusters in order.
+            // patchedIndex 0 -> GPO file offset clusterSize (first data cluster).
+            u32 gpoFileOffset = clusterSize * (1u + patchedIndex);
+            UINT br;
+            if (f_lseek(&gGpoFile, gpoFileOffset) == FR_OK)
+            {
+                f_read(&gGpoFile, (void*)(ROM_LINEAR_DS_ADDRESS + c * clusterSize), clusterSize, &br);
+            }
+            patchedIndex++;
+        }
+    }
+}

--- a/code/core/arm9/source/Patches/GpoPatcher.cpp
+++ b/code/core/arm9/source/Patches/GpoPatcher.cpp
@@ -167,30 +167,55 @@ extern FIL gFile; // Holds the GBA ROM file object and its cltbl
         f_close(&sVerifyFile);
         return false;
     }
+
+    if (memcmp(sVerifyHeader.magic, GPO_MAGIC, 4) != 0)  { f_close(&sVerifyFile); return false; }
+    if (sVerifyHeader.romSize      != romSize)            { f_close(&sVerifyFile); return false; }
+    if (sVerifyHeader.ipsSize      != ipsSize)            { f_close(&sVerifyFile); return false; }
+    if (sVerifyHeader.ipsTimestamp != ipsTime)            { f_close(&sVerifyFile); return false; }
+    if (sVerifyHeader.clusterSize  != clusterSize)        { f_close(&sVerifyFile); return false; }
+
+    // Compute P_rom: patched ROM cluster count, scoped to ROM region only
+    u32 totalRomClusters = (romSize + clusterSize - 1) / clusterSize;
+    u32 P_rom = 0;
+    for (u32 c = 0; c < totalRomClusters; c++)
+        if (c < 8192 && (sVerifyHeader.bitmask[c / 32] & (1u << (c % 32))))
+            P_rom++;
+
+    // Compute E: extension cluster count
+    u32 pRS = sVerifyHeader.patchedRomSize > 0
+        ? sVerifyHeader.patchedRomSize : romSize;
+    u32 patchedTotalClusters = (pRS + clusterSize - 1) / clusterSize;
+    u32 E = patchedTotalClusters > totalRomClusters
+        ? patchedTotalClusters - totalRomClusters : 0;
+
+    // GPO file must contain: 1 header cluster + P_rom patched clusters + E extension clusters
+    u32 expectedSize = (1 + P_rom + E) * clusterSize;
+    bool sizeOk = f_size(&sVerifyFile) >= expectedSize;
     f_close(&sVerifyFile);
-
-    if (memcmp(sVerifyHeader.magic, GPO_MAGIC, 4) != 0)
-        return false;
-    if (sVerifyHeader.romSize != romSize)
-        return false;
-    if (sVerifyHeader.ipsSize != ipsSize)
-        return false;
-    if (sVerifyHeader.ipsTimestamp != ipsTime)
-        return false;
-    if (sVerifyHeader.clusterSize != clusterSize)
-        return false;
-
-    return true;
+    return sizeOk;
 }
 
 [[gnu::section(".ewram")]] static bool createGpo(const char* romPath, const char* ipsPath, const char* gpoPath, u32 romSize, u32 ipsSize, u32 ipsTime, u32 clusterSize)
 {
-    if (f_open(&sRomFile, romPath, FA_READ | FA_OPEN_EXISTING) != FR_OK) return false;
-    if (f_open(&sIpsFile, ipsPath, FA_READ | FA_OPEN_EXISTING) != FR_OK) { f_close(&sRomFile); return false; }
+    if (clusterSize < sizeof(GpoHeader)) return false;
+
+    if (f_open(&sRomFile,      romPath, FA_READ  | FA_OPEN_EXISTING) != FR_OK) return false;
+    if (f_open(&sIpsFile,      ipsPath, FA_READ  | FA_OPEN_EXISTING) != FR_OK) { f_close(&sRomFile); return false; }
     if (f_open(&sWriteGpoFile, gpoPath, FA_WRITE | FA_CREATE_ALWAYS) != FR_OK) { f_close(&sRomFile); f_close(&sIpsFile); return false; }
 
-    memcpy(sCreateHeader.magic, GPO_MAGIC, 4);
+    auto cleanupAndAbort = [&]() -> bool {
+        f_close(&sRomFile);
+        f_close(&sIpsFile);
+        f_close(&sWriteGpoFile);
+        f_unlink(gpoPath);
+        return false;
+    };
+
+    // Write placeholder magic; will be promoted to GPO_MAGIC only on final committed rewrite.
+    // If power is lost mid-creation, verifyGpo rejects "GPOT" and triggers a clean rebuild next boot.
+    memcpy(sCreateHeader.magic, GPO_MAGIC_PLACEHOLDER, 4);
     sCreateHeader.romSize = romSize;
+    sCreateHeader.patchedRomSize = 0;  // filled in after Pass 1
     sCreateHeader.ipsSize = ipsSize;
     sCreateHeader.ipsTimestamp = ipsTime;
     sCreateHeader.clusterSize = clusterSize;
@@ -199,31 +224,38 @@ extern FIL gFile; // Holds the GBA ROM file object and its cltbl
     char ipsHeader[5];
     UINT br;
     if (f_read(&sIpsFile, ipsHeader, 5, &br) != FR_OK || br != 5 || memcmp(ipsHeader, "PATCH", 5) != 0)
-    {
-        f_close(&sRomFile); f_close(&sIpsFile); f_close(&sWriteGpoFile);
-        return false;
-    }
+        return cleanupAndAbort();
 
-    u32 blocksPerCluster = clusterSize / 4096;
-    if (blocksPerCluster == 0) blocksPerCluster = 1;
+    u32 maxHunkExtent = 0;
+    bool eofReached = false;
 
-    // Scan IPS to identify patched clusters
+    // Pass 1: scan IPS to identify patched clusters and find max hunk extent
     while (true)
     {
         u8 offsetBuf[3];
         if (f_read(&sIpsFile, offsetBuf, 3, &br) != FR_OK || br != 3) break;
-        u32 offset = (offsetBuf[0] << 16) | (offsetBuf[1] << 8) | offsetBuf[2];
-        if (offset == 0x454F46)
+        u32 offset = ((u32)offsetBuf[0] << 16) | ((u32)offsetBuf[1] << 8) | offsetBuf[2];
+
+        // SNESTool EOF ambiguity fix: treat 0x454F46 as EOF only if <= 3 bytes remain.
+        // A real hunk at this offset would need at least 2 size bytes + 1 data byte.
+        if (offset == 0x454F46 && (ipsSize - (u32)f_tell(&sIpsFile)) <= 3)
+        {
+            eofReached = true;
             break;
+        }
 
         u8 sizeBuf[2];
         if (f_read(&sIpsFile, sizeBuf, 2, &br) != FR_OK || br != 2) break;
-        u32 size = (sizeBuf[0] << 8) | sizeBuf[1];
+        u32 size = ((u32)sizeBuf[0] << 8) | sizeBuf[1];
 
         if (size > 0)
         {
+            if (offset + size > maxHunkExtent) maxHunkExtent = offset + size;
+
             u32 startBlock = offset / 4096;
-            u32 endBlock = (offset + size - 1) / 4096;
+            u32 endBlock   = (offset + size - 1) / 4096;
+            u32 blocksPerCluster = clusterSize / 4096;
+            if (blocksPerCluster == 0) blocksPerCluster = 1;
             for (u32 b = startBlock; b <= endBlock; b++)
             {
                 u32 c = b / blocksPerCluster;
@@ -231,22 +263,24 @@ extern FIL gFile; // Holds the GBA ROM file object and its cltbl
                     sCreateHeader.bitmask[c / 32] |= (1u << (c % 32));
             }
             if (f_lseek(&sIpsFile, f_tell(&sIpsFile) + size) != FR_OK)
-            {
-                f_close(&sRomFile); f_close(&sIpsFile); f_close(&sWriteGpoFile);
-                return false;
-            }
+                return cleanupAndAbort();
         }
         else
         {
             u8 countBuf[2];
             if (f_read(&sIpsFile, countBuf, 2, &br) != FR_OK || br != 2) break;
-            u32 count = (countBuf[0] << 8) | countBuf[1];
-            
+            u32 count = ((u32)countBuf[0] << 8) | countBuf[1];
+            if (count == 0) return cleanupAndAbort();  // corrupt RLE: infinite loop guard
+
             u8 val;
             if (f_read(&sIpsFile, &val, 1, &br) != FR_OK || br != 1) break;
 
+            if (offset + count > maxHunkExtent) maxHunkExtent = offset + count;
+
             u32 startBlock = offset / 4096;
-            u32 endBlock = (offset + count - 1) / 4096;
+            u32 endBlock   = (offset + count - 1) / 4096;
+            u32 blocksPerCluster = clusterSize / 4096;
+            if (blocksPerCluster == 0) blocksPerCluster = 1;
             for (u32 b = startBlock; b <= endBlock; b++)
             {
                 u32 c = b / blocksPerCluster;
@@ -256,118 +290,209 @@ extern FIL gFile; // Holds the GBA ROM file object and its cltbl
         }
     }
 
-    // Write header
-    UINT bw;
-    f_write(&sWriteGpoFile, &sCreateHeader, sizeof(sCreateHeader), &bw);
+    if (!eofReached) return cleanupAndAbort();
 
-    // Pad header to clusterSize using sTempBuf (already EWRAM static)
+    // Truncate field: IPS may have 3 optional bytes after EOF marker specifying new ROM size
+    u32 truncateValue = 0;
+    {
+        FSIZE_t remaining = ipsSize - f_tell(&sIpsFile);
+        if (remaining == 3)
+        {
+            u8 truncBuf[3];
+            if (f_read(&sIpsFile, truncBuf, 3, &br) == FR_OK && br == 3)
+                truncateValue = ((u32)truncBuf[0] << 16) | ((u32)truncBuf[1] << 8) | truncBuf[2];
+        }
+    }
+
+    // Effective ROM size after patch
+    u32 patchedRomSize = truncateValue > 0
+        ? truncateValue
+        : (maxHunkExtent > romSize ? maxHunkExtent : romSize);
+    sCreateHeader.patchedRomSize = patchedRomSize;
+
+    u32 totalRomClusters     = (romSize        + clusterSize - 1) / clusterSize;
+    u32 patchedTotalClusters = (patchedRomSize  + clusterSize - 1) / clusterSize;
+
+    // Clear bitmask bits outside [0, min(totalRomClusters, patchedTotalClusters)).
+    // Extension clusters do not use the bitmask; truncated-away clusters must not either.
+    u32 cleanBound = totalRomClusters < patchedTotalClusters
+        ? totalRomClusters : patchedTotalClusters;
+    for (u32 c = cleanBound; c < 8192; c++)
+        sCreateHeader.bitmask[c / 32] &= ~(1u << (c % 32));
+
+    // Write placeholder header (GPOT magic); promoted to GPO1 only at the end
+    UINT bw;
+    if (f_write(&sWriteGpoFile, &sCreateHeader, sizeof(sCreateHeader), &bw) != FR_OK
+        || bw != sizeof(sCreateHeader))
+        return cleanupAndAbort();
+
+    // Pad header cluster to clusterSize
     memset(sTempBuf, 0, sizeof(sTempBuf));
     u32 paddingBytes = clusterSize - sizeof(sCreateHeader);
     while (paddingBytes > 0)
     {
-        u32 chunk = paddingBytes > sizeof(sTempBuf) ? sizeof(sTempBuf) : paddingBytes;
-        f_write(&sWriteGpoFile, sTempBuf, chunk, &bw);
+        u32 chunk = paddingBytes > sizeof(sTempBuf) ? (u32)sizeof(sTempBuf) : paddingBytes;
+        if (f_write(&sWriteGpoFile, sTempBuf, chunk, &bw) != FR_OK || bw != chunk)
+            return cleanupAndAbort();
         paddingBytes -= chunk;
     }
 
-    // Write original GBA ROM clusters for patched clusters
-    u32 totalClusters = (romSize + clusterSize - 1) / clusterSize;
-    for (u32 c = 0; c < totalClusters; c++)
+    // Range A: copy ROM clusters that the IPS touches, up to min(totalRomClusters, patchedTotalClusters)
+    u32 rangeALimit = totalRomClusters < patchedTotalClusters
+        ? totalRomClusters : patchedTotalClusters;
+    for (u32 c = 0; c < rangeALimit; c++)
     {
-        if (sCreateHeader.bitmask[c / 32] & (1u << (c % 32)))
+        if (c >= 8192 || !(sCreateHeader.bitmask[c / 32] & (1u << (c % 32))))
+            continue;
+
+        if (f_lseek(&sRomFile, (FSIZE_t)c * clusterSize) != FR_OK)
+            return cleanupAndAbort();
+
+        u32 remaining = clusterSize;
+        while (remaining > 0)
         {
-            f_lseek(&sRomFile, c * clusterSize);
+            u32 chunk = remaining > sizeof(sTempBuf) ? (u32)sizeof(sTempBuf) : remaining;
+            memset(sTempBuf, 0xFF, chunk);  // pre-fill so short reads yield open-bus 0xFF
+            if (f_read(&sRomFile, sTempBuf, chunk, &br) != FR_OK)
+                return cleanupAndAbort();
+            if (f_write(&sWriteGpoFile, sTempBuf, chunk, &bw) != FR_OK || bw != chunk)
+                return cleanupAndAbort();
+            remaining -= chunk;
+        }
+    }
+
+    // Range B: extension clusters (past original ROM end), filled with 0xFF open-bus value.
+    // The IPS apply phase (Pass 2) will overwrite the relevant bytes afterward.
+    if (patchedTotalClusters > totalRomClusters)
+    {
+        memset(sTempBuf, 0xFF, sizeof(sTempBuf));
+        for (u32 c = totalRomClusters; c < patchedTotalClusters; c++)
+        {
             u32 remaining = clusterSize;
             while (remaining > 0)
             {
-                u32 chunk = remaining > 4096 ? 4096 : remaining;
-                memset(sTempBuf, 0xFF, chunk);
-                f_read(&sRomFile, sTempBuf, chunk, &br);
-                f_write(&sWriteGpoFile, sTempBuf, chunk, &bw);
+                u32 chunk = remaining > sizeof(sTempBuf) ? (u32)sizeof(sTempBuf) : remaining;
+                if (f_write(&sWriteGpoFile, sTempBuf, chunk, &bw) != FR_OK || bw != chunk)
+                    return cleanupAndAbort();
                 remaining -= chunk;
             }
         }
     }
 
-    // Apply patches to GPO
-    f_lseek(&sIpsFile, 5);
+    // Pass 2: Apply IPS patches to GPO file
+    if (f_lseek(&sIpsFile, 5) != FR_OK) return cleanupAndAbort();
 
-    auto writePatchToGpo = [&](u32 romOffset, const u8* data, u32 dataSize) {
+    // Precompute patched ROM cluster count (scoped to ROM region only; extension clusters use no bitmask bits)
+    u32 patchedRomClusterCount = 0;
+    for (u32 c = 0; c < totalRomClusters; c++)
+        if (c < 8192 && (sCreateHeader.bitmask[c / 32] & (1u << (c % 32))))
+            patchedRomClusterCount++;
+
+    // writePatchToGpo: apply a contiguous data buffer to the GPO file at the right cluster offset.
+    // Returns false on any I/O error (caller must cleanupAndAbort).
+    auto writePatchToGpo = [&](u32 romOffset, const u8* data, u32 dataSize) -> bool {
         u32 startCluster = romOffset / clusterSize;
-        u32 endCluster = (romOffset + dataSize - 1) / clusterSize;
+        u32 endCluster   = (romOffset + dataSize - 1) / clusterSize;
         for (u32 c = startCluster; c <= endCluster; c++)
         {
-            if (c >= 8192) continue;
-            if (!(sCreateHeader.bitmask[c / 32] & (1u << (c % 32)))) continue;
+            if (c >= patchedTotalClusters) continue;  // truncation guard
 
-            u32 patchedClusterIndex = 0;
-            for (u32 i = 0; i < c / 32; i++)
-                patchedClusterIndex += gPopCountTable.PopCount(sCreateHeader.bitmask[i]);
-            patchedClusterIndex += gPopCountTable.PopCount(sCreateHeader.bitmask[c / 32] & ((1u << (c % 32)) - 1));
-            
             u32 clusterStartOffset = c * clusterSize;
-            u32 clusterEndOffset = clusterStartOffset + clusterSize;
-            
+            u32 clusterEndOffset   = clusterStartOffset + clusterSize;
             u32 patchStart = romOffset > clusterStartOffset ? romOffset : clusterStartOffset;
-            u32 patchEnd = (romOffset + dataSize) < clusterEndOffset ? (romOffset + dataSize) : clusterEndOffset;
-            
-            if (patchStart < patchEnd)
+            u32 patchEnd   = (romOffset + dataSize) < clusterEndOffset
+                             ? (romOffset + dataSize) : clusterEndOffset;
+            if (patchStart >= patchEnd) continue;
+
+            u32 gpoIdx;
+            if (c >= totalRomClusters)
             {
-                u32 targetFileOffset = clusterSize + patchedClusterIndex * clusterSize + (patchStart - clusterStartOffset);
-                f_lseek(&sWriteGpoFile, targetFileOffset);
-                f_write(&sWriteGpoFile, data + (patchStart - romOffset), patchEnd - patchStart, &bw);
+                // Extension cluster: sequential after all patched ROM clusters in GPO
+                gpoIdx = patchedRomClusterCount + (c - totalRomClusters);
             }
+            else
+            {
+                // c < 8192 guard: small-cluster SD cards can have totalRomClusters > 8192
+                if (c >= 8192 || !(sCreateHeader.bitmask[c / 32] & (1u << (c % 32)))) continue;
+                gpoIdx = 0;
+                for (u32 i = 0; i < c / 32; i++)
+                    gpoIdx += gPopCountTable.PopCount(sCreateHeader.bitmask[i]);
+                gpoIdx += gPopCountTable.PopCount(sCreateHeader.bitmask[c / 32] & ((1u << (c % 32)) - 1));
+            }
+
+            u32 targetFileOffset = clusterSize + gpoIdx * clusterSize + (patchStart - clusterStartOffset);
+            UINT bw2;
+            if (f_lseek(&sWriteGpoFile, targetFileOffset) != FR_OK) return false;
+            if (f_write(&sWriteGpoFile, data + (patchStart - romOffset), patchEnd - patchStart, &bw2) != FR_OK
+                || bw2 != (patchEnd - patchStart)) return false;
         }
+        return true;
     };
 
-    auto writeRleToGpo = [&](u32 romOffset, u8 val, u32 count) {
+    // writeRleToGpo: apply an RLE hunk to the GPO file.
+    // Returns false on any I/O error.
+    auto writeRleToGpo = [&](u32 romOffset, u8 val, u32 count) -> bool {
         u32 startCluster = romOffset / clusterSize;
-        u32 endCluster = (romOffset + count - 1) / clusterSize;
+        u32 endCluster   = (romOffset + count - 1) / clusterSize;
         for (u32 c = startCluster; c <= endCluster; c++)
         {
-            if (c >= 8192) continue;
-            if (!(sCreateHeader.bitmask[c / 32] & (1u << (c % 32)))) continue;
+            if (c >= patchedTotalClusters) continue;  // truncation guard
 
-            u32 patchedClusterIndex = 0;
-            for (u32 i = 0; i < c / 32; i++)
-                patchedClusterIndex += gPopCountTable.PopCount(sCreateHeader.bitmask[i]);
-            patchedClusterIndex += gPopCountTable.PopCount(sCreateHeader.bitmask[c / 32] & ((1u << (c % 32)) - 1));
-            
             u32 clusterStartOffset = c * clusterSize;
-            u32 clusterEndOffset = clusterStartOffset + clusterSize;
-            
+            u32 clusterEndOffset   = clusterStartOffset + clusterSize;
             u32 patchStart = romOffset > clusterStartOffset ? romOffset : clusterStartOffset;
-            u32 patchEnd = (romOffset + count) < clusterEndOffset ? (romOffset + count) : clusterEndOffset;
-            
-            if (patchStart < patchEnd)
+            u32 patchEnd   = (romOffset + count) < clusterEndOffset
+                             ? (romOffset + count) : clusterEndOffset;
+            if (patchStart >= patchEnd) continue;
+
+            u32 gpoIdx;
+            if (c >= totalRomClusters)
             {
-                u32 targetFileOffset = clusterSize + patchedClusterIndex * clusterSize + (patchStart - clusterStartOffset);
-                f_lseek(&sWriteGpoFile, targetFileOffset);
-                u32 writeLen = patchEnd - patchStart;
-                
-                u32 remaining = writeLen;
-                memset(sTempBuf, val, clusterSize < 4096 ? clusterSize : 4096);
-                while (remaining > 0)
-                {
-                    u32 chunk = remaining > 4096 ? 4096 : remaining;
-                    f_write(&sWriteGpoFile, sTempBuf, chunk, &bw);
-                    remaining -= chunk;
-                }
+                gpoIdx = patchedRomClusterCount + (c - totalRomClusters);
+            }
+            else
+            {
+                if (c >= 8192 || !(sCreateHeader.bitmask[c / 32] & (1u << (c % 32)))) continue;
+                gpoIdx = 0;
+                for (u32 i = 0; i < c / 32; i++)
+                    gpoIdx += gPopCountTable.PopCount(sCreateHeader.bitmask[i]);
+                gpoIdx += gPopCountTable.PopCount(sCreateHeader.bitmask[c / 32] & ((1u << (c % 32)) - 1));
+            }
+
+            u32 targetFileOffset = clusterSize + gpoIdx * clusterSize + (patchStart - clusterStartOffset);
+            UINT bw2;
+            if (f_lseek(&sWriteGpoFile, targetFileOffset) != FR_OK) return false;
+
+            u32 writeLen = patchEnd - patchStart;
+            u32 fillSize = sizeof(sTempBuf) < clusterSize ? sizeof(sTempBuf) : clusterSize;
+            memset(sTempBuf, val, fillSize);
+            u32 remaining = writeLen;
+            while (remaining > 0)
+            {
+                u32 chunk = remaining > sizeof(sTempBuf) ? (u32)sizeof(sTempBuf) : remaining;
+                if (f_write(&sWriteGpoFile, sTempBuf, chunk, &bw2) != FR_OK || bw2 != chunk) return false;
+                remaining -= chunk;
             }
         }
+        return true;
     };
 
+    bool pass2Eof = false;
     while (true)
     {
         u8 offsetBuf[3];
         if (f_read(&sIpsFile, offsetBuf, 3, &br) != FR_OK || br != 3) break;
-        u32 offset = (offsetBuf[0] << 16) | (offsetBuf[1] << 8) | offsetBuf[2];
-        if (offset == 0x454F46)
+        u32 offset = ((u32)offsetBuf[0] << 16) | ((u32)offsetBuf[1] << 8) | offsetBuf[2];
+
+        if (offset == 0x454F46 && (ipsSize - (u32)f_tell(&sIpsFile)) <= 3)
+        {
+            pass2Eof = true;
             break;
+        }
 
         u8 sizeBuf[2];
         if (f_read(&sIpsFile, sizeBuf, 2, &br) != FR_OK || br != 2) break;
-        u32 size = (sizeBuf[0] << 8) | sizeBuf[1];
+        u32 size = ((u32)sizeBuf[0] << 8) | sizeBuf[1];
 
         if (size > 0)
         {
@@ -375,9 +500,11 @@ extern FIL gFile; // Holds the GBA ROM file object and its cltbl
             u32 currentOffset = offset;
             while (remaining > 0)
             {
-                u32 chunk = remaining > 4096 ? 4096 : remaining;
-                f_read(&sIpsFile, sTempBuf, chunk, &br);
-                writePatchToGpo(currentOffset, sTempBuf, chunk);
+                u32 chunk = remaining > sizeof(sTempBuf) ? (u32)sizeof(sTempBuf) : remaining;
+                if (f_read(&sIpsFile, sTempBuf, chunk, &br) != FR_OK || br != chunk)
+                    return cleanupAndAbort();
+                if (!writePatchToGpo(currentOffset, sTempBuf, chunk))
+                    return cleanupAndAbort();
                 currentOffset += chunk;
                 remaining -= chunk;
             }
@@ -386,17 +513,26 @@ extern FIL gFile; // Holds the GBA ROM file object and its cltbl
         {
             u8 countBuf[2];
             if (f_read(&sIpsFile, countBuf, 2, &br) != FR_OK || br != 2) break;
-            u32 count = (countBuf[0] << 8) | countBuf[1];
-            
+            u32 count = ((u32)countBuf[0] << 8) | countBuf[1];
+            if (count == 0) return cleanupAndAbort();
+
             u8 val;
-            f_read(&sIpsFile, &val, 1, &br);
-            
-            writeRleToGpo(offset, val, count);
+            if (f_read(&sIpsFile, &val, 1, &br) != FR_OK || br != 1) break;
+
+            if (!writeRleToGpo(offset, val, count))
+                return cleanupAndAbort();
         }
     }
 
-    f_lseek(&sWriteGpoFile, 0);
-    f_write(&sWriteGpoFile, &sCreateHeader, sizeof(sCreateHeader), &bw);
+    // A truncated IPS (no EOF marker in Pass 2) must not commit the GPO
+    if (!pass2Eof) return cleanupAndAbort();
+
+    // Final header commit: promote placeholder magic to GPO_MAGIC
+    memcpy(sCreateHeader.magic, GPO_MAGIC, 4);
+    if (f_lseek(&sWriteGpoFile, 0) != FR_OK) return cleanupAndAbort();
+    if (f_write(&sWriteGpoFile, &sCreateHeader, sizeof(sCreateHeader), &bw) != FR_OK
+        || bw != sizeof(sCreateHeader))
+        return cleanupAndAbort();
 
     f_close(&sRomFile);
     f_close(&sIpsFile);
@@ -433,45 +569,57 @@ struct ClmtTracker
     }
 };
 
-[[gnu::section(".ewram")]] static bool mergeClusterMaps(u32 romSize, u32 clusterSize)
+[[gnu::section(".ewram")]] static bool mergeClusterMaps(u32 romSize, u32 patchedRomSize, u32 clusterSize)
 {
-    u32 totalClusters = (romSize + clusterSize - 1) / clusterSize;
-    
+    u32 totalRomClusters     = (romSize        + clusterSize - 1) / clusterSize;
+    u32 patchedTotalClusters = (patchedRomSize  + clusterSize - 1) / clusterSize;
+
+    // patchedRomClusterCount: popcount of bitmask scoped to ROM region only.
+    // Extension clusters do not set bitmask bits, so this must not count past totalRomClusters.
+    u32 patchedRomClusterCount = 0;
+    for (u32 c = 0; c < totalRomClusters; c++)
+        if (c < 8192 && (gGpoBitmask[c / 32] & (1u << (c % 32))))
+            patchedRomClusterCount++;
+
     DWORD* dest = sMergedClusterTable + 1;
     u32 tableLimit = 2048 - 2;
-    
-    u32 fragmentCount = 0;
-    u32 currentFragSize = 0;
+
+    u32 fragmentCount      = 0;
+    u32 currentFragSize    = 0;
     DWORD currentFragStartPhys = 0;
-    
     u32 patchedClusterIndex = 0;
-    
+
     ClmtTracker romTracker;
     romTracker.Init(gFile.cltbl);
-    
+
     ClmtTracker gpoTracker;
     gpoTracker.Init(sGpoClusterTable);
-    
-    for (u32 c = 0; c < totalClusters; c++)
+
+    for (u32 c = 0; c < patchedTotalClusters; c++)
     {
-        bool isPatched = c < 8192 && (gGpoBitmask[c / 32] & (1u << (c % 32)));
-        
         DWORD physCl = 0;
-        if (isPatched)
+        if (c >= totalRomClusters)
         {
-            physCl = gpoTracker.GetPhysicalCluster(1 + patchedClusterIndex);
-            patchedClusterIndex++;
+            // Extension cluster: always from GPO, sequentially after all patched ROM clusters.
+            // ClmtTracker monotone contract holds: indices are 1..P_rom then P_rom+1..P_rom+E.
+            physCl = gpoTracker.GetPhysicalCluster(1 + patchedRomClusterCount + (c - totalRomClusters));
         }
         else
         {
-            physCl = romTracker.GetPhysicalCluster(c);
+            bool isPatched = c < 8192 && (gGpoBitmask[c / 32] & (1u << (c % 32)));
+            if (isPatched)
+            {
+                physCl = gpoTracker.GetPhysicalCluster(1 + patchedClusterIndex);
+                patchedClusterIndex++;
+            }
+            else
+            {
+                physCl = romTracker.GetPhysicalCluster(c);
+            }
         }
-        
-        if (physCl == 0)
-        {
-            return false;
-        }
-        
+
+        if (physCl == 0) return false;
+
         if (currentFragSize == 0)
         {
             currentFragSize = 1;
@@ -483,30 +631,24 @@ struct ClmtTracker
         }
         else
         {
-            if ((u32)(dest - sMergedClusterTable) >= tableLimit)
-            {
-                return false;
-            }
+            if ((u32)(dest - sMergedClusterTable) >= tableLimit) return false;
             *dest++ = currentFragSize;
             *dest++ = currentFragStartPhys;
             fragmentCount++;
-            
+
             currentFragSize = 1;
             currentFragStartPhys = physCl;
         }
     }
-    
+
     if (currentFragSize > 0)
     {
-        if ((u32)(dest - sMergedClusterTable) >= tableLimit)
-        {
-            return false;
-        }
+        if ((u32)(dest - sMergedClusterTable) >= tableLimit) return false;
         *dest++ = currentFragSize;
         *dest++ = currentFragStartPhys;
         fragmentCount++;
     }
-    
+
     *dest = 0;
     sMergedClusterTable[0] = (dest - sMergedClusterTable);
     return true;
@@ -518,10 +660,9 @@ struct ClmtTracker
     if (!gLogger) return;
     gLogger->Log(LogLevel::Debug, "[GPO Test] Running mergeClusterMaps unit tests...\n");
 
-    // Backup original cltbl
     DWORD* origCltbl = gFile.cltbl;
 
-    // Mock GBA ROM cluster table (representing 1000 clusters contiguously starting at cluster 100)
+    // Mock ROM CLMT: 1000 clusters contiguous starting at physical cluster 100
     DWORD gbaCltblMock[4];
     gbaCltblMock[0] = 3;
     gbaCltblMock[1] = 1000;
@@ -529,41 +670,55 @@ struct ClmtTracker
     gbaCltblMock[3] = 0;
     gFile.cltbl = gbaCltblMock;
 
-    // Mock GPO cluster table (representing 2000 clusters contiguously starting at cluster 5000)
+    // Mock GPO CLMT: 2000 clusters contiguous starting at physical cluster 5000
     sGpoClusterTable[0] = 3;
     sGpoClusterTable[1] = 2000;
     sGpoClusterTable[2] = 5000;
     sGpoClusterTable[3] = 0;
 
-    // Test 1: Merge under limit (200 clusters, alternating)
-    // Alternate every odd cluster
+    // Test 1: Merge under limit (200 ROM clusters, every-other patched, no extension)
     memset(gGpoBitmask, 0, sizeof(gGpoBitmask));
     for (u32 i = 0; i < 200; i++)
-    {
         if (i % 2 == 1)
-        {
             gGpoBitmask[i / 32] |= (1u << (i % 32));
-        }
-    }
-    bool res1 = mergeClusterMaps(200 * 4096, 4096);
-    gLogger->Log(LogLevel::Debug, "[GPO Test] Merge under limit (200 clusters, alternating): %s (expected: true)\n", res1 ? "PASS" : "FAIL");
+    bool res1 = mergeClusterMaps(200 * 4096, 200 * 4096, 4096);
+    gLogger->Log(LogLevel::Debug, "[GPO Test] 1 - Merge under limit (no extension): %s\n", res1 ? "PASS" : "FAIL");
 
-    // Test 2: Merge over limit to trigger overflow
-    // Alternating 1100 clusters produces ~1100 fragments; limit is 1023, so this must overflow.
+    // Test 2: Merge over limit triggers overflow (alternating 1100 clusters ~= 1100 fragments, limit 1023)
     memset(gGpoBitmask, 0, sizeof(gGpoBitmask));
     for (u32 i = 0; i < 1100; i++)
-    {
         if (i % 2 == 1)
-        {
             gGpoBitmask[i / 32] |= (1u << (i % 32));
-        }
-    }
-    bool res2 = mergeClusterMaps(1100 * 4096, 4096);
-    gLogger->Log(LogLevel::Debug, "[GPO Test] Merge over limit (1100 clusters, alternating): %s (expected: false)\n", !res2 ? "PASS" : "FAIL");
+    bool res2 = mergeClusterMaps(1100 * 4096, 1100 * 4096, 4096);
+    gLogger->Log(LogLevel::Debug, "[GPO Test] 2 - Merge overflow (expected false): %s\n", !res2 ? "PASS" : "FAIL");
 
-    // Restore original state
+    // Test 3: ROM extension -- 100 ROM clusters, 10 extension clusters (patchedRomSize = 110 clusters)
+    // GPO CLMT has 2000 clusters; 100 patched ROM + 10 extension = 110 needed -- fits.
+    // All 100 ROM clusters are patched (bitmask all 1s in [0..99]).
+    memset(gGpoBitmask, 0, sizeof(gGpoBitmask));
+    for (u32 i = 0; i < 100; i++)
+        gGpoBitmask[i / 32] |= (1u << (i % 32));
+    bool res3 = mergeClusterMaps(100 * 4096, 110 * 4096, 4096);
+    gLogger->Log(LogLevel::Debug, "[GPO Test] 3 - ROM extension (100 ROM + 10 ext): %s\n", res3 ? "PASS" : "FAIL");
+
+    // Test 4: ROM truncation -- 100 ROM clusters, patchedRomSize = 50 clusters. Merge stops at 50.
+    memset(gGpoBitmask, 0, sizeof(gGpoBitmask));
+    for (u32 i = 0; i < 50; i++)
+        gGpoBitmask[i / 32] |= (1u << (i % 32));
+    bool res4 = mergeClusterMaps(100 * 4096, 50 * 4096, 4096);
+    gLogger->Log(LogLevel::Debug, "[GPO Test] 4 - ROM truncation (100 ROM -> 50): %s\n", res4 ? "PASS" : "FAIL");
+
+    // Test 5: Unchanged size (patchedRomSize == romSize) -- identical to pre-extension behavior.
+    memset(gGpoBitmask, 0, sizeof(gGpoBitmask));
+    for (u32 i = 0; i < 200; i++)
+        if (i % 2 == 1)
+            gGpoBitmask[i / 32] |= (1u << (i % 32));
+    bool res5 = mergeClusterMaps(200 * 4096, 200 * 4096, 4096);
+    gLogger->Log(LogLevel::Debug, "[GPO Test] 5 - Unchanged size: %s\n", res5 ? "PASS" : "FAIL");
+
     gFile.cltbl = origCltbl;
     memset(gGpoBitmask, 0, sizeof(gGpoBitmask));
+    gLogger->Log(LogLevel::Debug, "[GPO Test] Done.\n");
 }
 #endif
 
@@ -664,7 +819,10 @@ extern "C" [[gnu::section(".ewram")]] bool gpo_init(const char* romPath)
     log_debug(romPath, "sGpoClusterTable[0] size after CREATE_LINKMAP:", sGpoClusterTable[0]);
 #endif
 
-    if (!mergeClusterMaps(romSize, clusterSize))
+    u32 activeRomSize = sVerifyHeader.patchedRomSize > 0
+        ? sVerifyHeader.patchedRomSize : romSize;
+
+    if (!mergeClusterMaps(romSize, activeRomSize, clusterSize))
     {
 #ifndef NDEBUG
         log_debug(romPath, "mergeClusterMaps failed!");
@@ -673,6 +831,10 @@ extern "C" [[gnu::section(".ewram")]] bool gpo_init(const char* romPath)
         return false;
     }
 
+    // Update SdCache bounds before swapping the CLMT; SdCache uses gFile.obj.objsize as
+    // the upper bound for read validation. Must be set before gFile.cltbl so that the
+    // first f_read after the swap sees the correct limit.
+    gFile.obj.objsize = activeRomSize;
     gFile.cltbl = sMergedClusterTable;
 
 #ifndef NDEBUG
@@ -687,26 +849,44 @@ extern "C" [[gnu::section(".ewram")]] bool gpo_init(const char* romPath)
 // After the linear chunk is loaded via f_read, FatFS serves cluster 0 from gFile.obj.sclust
 // (bypassing the merged CLMT) because fptr==0 triggers the sclust fallback.  Any IPS patch
 // that touches cluster 0 is therefore not applied.  This function corrects that by reading
-// every patched cluster that falls inside the linear window directly from gGpoFile, whose
-// own CLMT (sGpoClusterTable) has no fptr==0 ambiguity for these seeks.
+// every patched cluster that falls inside the linear window directly from gGpoFile.
+// Extension clusters inside the window (only possible on ROMs < 2MB) are also loaded here.
 extern "C" [[gnu::section(".ewram")]] void gpo_patchLinearChunk(u32 clusterSize, u32 linearChunkSize)
 {
-    u32 maxLinearCluster = linearChunkSize / clusterSize;
-    u32 limit = maxLinearCluster < 8192u ? maxLinearCluster : 8192u;
-    u32 patchedIndex = 0;
+    u32 romSize          = sVerifyHeader.romSize;
+    u32 patchedRomSize   = sVerifyHeader.patchedRomSize > 0
+                           ? sVerifyHeader.patchedRomSize : (u32)gFile.obj.objsize;
+    u32 totalRomClusters     = (romSize       + clusterSize - 1) / clusterSize;
+    u32 patchedTotalClusters = (patchedRomSize + clusterSize - 1) / clusterSize;
 
+    // Precompute P_rom for extension cluster GPO offset calculation
+    u32 patchedRomClusterCount = 0;
+    for (u32 c = 0; c < totalRomClusters; c++)
+        if (c < 8192 && (gGpoBitmask[c / 32] & (1u << (c % 32))))
+            patchedRomClusterCount++;
+
+    u32 maxLinearCluster = linearChunkSize / clusterSize;
+    u32 limit = maxLinearCluster < patchedTotalClusters ? maxLinearCluster : patchedTotalClusters;
+    if (limit > 8192u) limit = 8192u;  // bitmask has 8192 entries max
+
+    u32 patchedIndex = 0;
     for (u32 c = 0; c < limit; c++)
     {
-        if (gGpoBitmask[c / 32] & (1u << (c % 32)))
+        if (c >= totalRomClusters)
         {
-            // GPO file layout: one header cluster (padded), then patched ROM clusters in order.
-            // patchedIndex 0 -> GPO file offset clusterSize (first data cluster).
+            // Extension cluster: sequential in GPO after all patched ROM clusters
+            u32 gpoFileOffset = clusterSize * (1u + patchedRomClusterCount + (c - totalRomClusters));
+            UINT br;
+            if (f_lseek(&gGpoFile, gpoFileOffset) == FR_OK)
+                f_read(&gGpoFile, (void*)(ROM_LINEAR_DS_ADDRESS + c * clusterSize), clusterSize, &br);
+        }
+        else if (c < 8192 && (gGpoBitmask[c / 32] & (1u << (c % 32))))
+        {
+            // Patched ROM cluster: sequential in GPO after the header cluster
             u32 gpoFileOffset = clusterSize * (1u + patchedIndex);
             UINT br;
             if (f_lseek(&gGpoFile, gpoFileOffset) == FR_OK)
-            {
                 f_read(&gGpoFile, (void*)(ROM_LINEAR_DS_ADDRESS + c * clusterSize), clusterSize, &br);
-            }
             patchedIndex++;
         }
     }

--- a/code/core/arm9/source/Patches/GpoPatcher.cpp
+++ b/code/core/arm9/source/Patches/GpoPatcher.cpp
@@ -1,5 +1,6 @@
 #include "GpoPatcher.h"
-#include "PopCountTable.h"
+#include "GpoBuilder.h"
+#include "UpsPatcher.h"
 #include "MemoryEmulator/RomDefs.h"
 #include <string.h>
 #include <stdlib.h>
@@ -16,33 +17,18 @@ static DWORD sGpoClusterTable[512];
 [[gnu::section(".ewram.bss"), gnu::aligned(32)]]
 static DWORD sMergedClusterTable[2048];
 
-[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
-static u8 sTempBuf[4096];
-
 // Static allocations in EWRAM BSS to prevent stack overflow in DTCM
-[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
-static FIL sVerifyFile;
-
-[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
-static FIL sRomFile;
-
-[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
-static FIL sIpsFile;
-
-[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
-static FIL sWriteGpoFile;
-
-[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
-static FIL sLogFile;
-
 [[gnu::section(".ewram.bss"), gnu::aligned(32)]]
 static FILINFO sFnoIps;
 
 [[gnu::section(".ewram.bss"), gnu::aligned(32)]]
-static FILINFO sFnoRom;
+static char sIpsPath[256];
 
 [[gnu::section(".ewram.bss"), gnu::aligned(32)]]
-static char sIpsPath[256];
+static char sUpsPath[256];
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static FILINFO sFnoUps;
 
 [[gnu::section(".ewram.bss"), gnu::aligned(32)]]
 static char sGpoPath[256];
@@ -51,494 +37,9 @@ static char sGpoPath[256];
 static char sLogPath[256];
 
 [[gnu::section(".ewram.bss"), gnu::aligned(32)]]
-static GpoHeader sVerifyHeader;
-
-[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
-static GpoHeader sCreateHeader;
+static GpoHeader sActiveGpoHeader;
 
 extern FIL gFile; // Holds the GBA ROM file object and its cltbl
-
-[[gnu::section(".ewram")]] static void gpo_getPath(const char* romPath, char* outPath, const char* ext)
-{
-    strcpy(outPath, romPath);
-    char* dot = strrchr(outPath, '.');
-    if (dot)
-    {
-        strcpy(dot, ext);
-    }
-    else
-    {
-        strcat(outPath, ext);
-    }
-}
-
-[[gnu::section(".ewram")]] static void u32_to_str(u32 val, char* buf)
-{
-    char temp[16];
-    int i = 0;
-    if (val == 0)
-    {
-        buf[0] = '0';
-        buf[1] = '\0';
-        return;
-    }
-    while (val > 0)
-    {
-        temp[i++] = '0' + (val % 10);
-        val /= 10;
-    }
-    for (int j = 0; j < i; j++)
-    {
-        buf[j] = temp[i - 1 - j];
-    }
-    buf[i] = '\0';
-}
-
-[[gnu::section(".ewram")]] static void log_debug(const char* romPath, const char* msg, u32 val1 = 0xFFFFFFFF, u32 val2 = 0xFFFFFFFF)
-{
-    gpo_getPath(romPath, sLogPath, "_gpo.log");
-    if (f_open(&sLogFile, sLogPath, FA_WRITE | FA_OPEN_ALWAYS) == FR_OK)
-    {
-        f_lseek(&sLogFile, f_size(&sLogFile));
-        UINT bw;
-        f_write(&sLogFile, msg, strlen(msg), &bw);
-        if (val1 != 0xFFFFFFFF)
-        {
-            char valBuf[16];
-            u32_to_str(val1, valBuf);
-            f_write(&sLogFile, " val1: ", 7, &bw);
-            f_write(&sLogFile, valBuf, strlen(valBuf), &bw);
-        }
-        if (val2 != 0xFFFFFFFF)
-        {
-            char valBuf[16];
-            u32_to_str(val2, valBuf);
-            f_write(&sLogFile, " val2: ", 7, &bw);
-            f_write(&sLogFile, valBuf, strlen(valBuf), &bw);
-        }
-        f_write(&sLogFile, "\n", 1, &bw);
-        f_close(&sLogFile);
-    }
-}
-
-[[gnu::section(".ewram")]] static void log_table(const char* romPath, const DWORD* tbl)
-{
-    gpo_getPath(romPath, sLogPath, "_gpo.log");
-    if (f_open(&sLogFile, sLogPath, FA_WRITE | FA_OPEN_ALWAYS) == FR_OK)
-    {
-        f_lseek(&sLogFile, f_size(&sLogFile));
-        UINT bw;
-        f_write(&sLogFile, "--- Merged Linkmap ---\n", 23, &bw);
-        u32 totalDwords = tbl[0];
-        char szBuf[16];
-        u32_to_str(totalDwords, szBuf);
-        f_write(&sLogFile, "Total DWORDs: ", 14, &bw);
-        f_write(&sLogFile, szBuf, strlen(szBuf), &bw);
-        f_write(&sLogFile, "\n", 1, &bw);
-        
-        for (u32 i = 1; i < totalDwords; i += 2)
-        {
-            char idxBuf[16], sizeBuf[16], startBuf[16];
-            u32_to_str(i / 2, idxBuf);
-            u32_to_str(tbl[i], sizeBuf);
-            u32_to_str(tbl[i+1], startBuf);
-            
-            f_write(&sLogFile, " Frag ", 6, &bw);
-            f_write(&sLogFile, idxBuf, strlen(idxBuf), &bw);
-            f_write(&sLogFile, ": size=", 7, &bw);
-            f_write(&sLogFile, sizeBuf, strlen(sizeBuf), &bw);
-            f_write(&sLogFile, " startCl=", 9, &bw);
-            f_write(&sLogFile, startBuf, strlen(startBuf), &bw);
-            f_write(&sLogFile, "\n", 1, &bw);
-        }
-        f_write(&sLogFile, "----------------------\n", 23, &bw);
-        f_close(&sLogFile);
-    }
-}
-
-[[gnu::section(".ewram")]] static bool verifyGpo(const char* gpoPath, u32 romSize, u32 ipsSize, u32 ipsTime, u32 clusterSize)
-{
-    if (f_open(&sVerifyFile, gpoPath, FA_READ | FA_OPEN_EXISTING) != FR_OK)
-        return false;
-
-    UINT br;
-    if (f_read(&sVerifyFile, &sVerifyHeader, sizeof(sVerifyHeader), &br) != FR_OK || br != sizeof(sVerifyHeader))
-    {
-        f_close(&sVerifyFile);
-        return false;
-    }
-
-    if (memcmp(sVerifyHeader.magic, GPO_MAGIC, 4) != 0)  { f_close(&sVerifyFile); return false; }
-    if (sVerifyHeader.romSize      != romSize)            { f_close(&sVerifyFile); return false; }
-    if (sVerifyHeader.ipsSize      != ipsSize)            { f_close(&sVerifyFile); return false; }
-    if (sVerifyHeader.ipsTimestamp != ipsTime)            { f_close(&sVerifyFile); return false; }
-    if (sVerifyHeader.clusterSize  != clusterSize)        { f_close(&sVerifyFile); return false; }
-
-    // Compute P_rom: patched ROM cluster count, scoped to ROM region only
-    u32 totalRomClusters = (romSize + clusterSize - 1) / clusterSize;
-    u32 P_rom = 0;
-    for (u32 c = 0; c < totalRomClusters; c++)
-        if (c < 8192 && (sVerifyHeader.bitmask[c / 32] & (1u << (c % 32))))
-            P_rom++;
-
-    // Compute E: extension cluster count
-    u32 pRS = sVerifyHeader.patchedRomSize > 0
-        ? sVerifyHeader.patchedRomSize : romSize;
-    u32 patchedTotalClusters = (pRS + clusterSize - 1) / clusterSize;
-    u32 E = patchedTotalClusters > totalRomClusters
-        ? patchedTotalClusters - totalRomClusters : 0;
-
-    // GPO file must contain: 1 header cluster + P_rom patched clusters + E extension clusters
-    u32 expectedSize = (1 + P_rom + E) * clusterSize;
-    bool sizeOk = f_size(&sVerifyFile) >= expectedSize;
-    f_close(&sVerifyFile);
-    return sizeOk;
-}
-
-[[gnu::section(".ewram")]] static bool createGpo(const char* romPath, const char* ipsPath, const char* gpoPath, u32 romSize, u32 ipsSize, u32 ipsTime, u32 clusterSize)
-{
-    if (clusterSize < sizeof(GpoHeader)) return false;
-
-    if (f_open(&sRomFile,      romPath, FA_READ  | FA_OPEN_EXISTING) != FR_OK) return false;
-    if (f_open(&sIpsFile,      ipsPath, FA_READ  | FA_OPEN_EXISTING) != FR_OK) { f_close(&sRomFile); return false; }
-    if (f_open(&sWriteGpoFile, gpoPath, FA_WRITE | FA_CREATE_ALWAYS) != FR_OK) { f_close(&sRomFile); f_close(&sIpsFile); return false; }
-
-    auto cleanupAndAbort = [&]() -> bool {
-        f_close(&sRomFile);
-        f_close(&sIpsFile);
-        f_close(&sWriteGpoFile);
-        f_unlink(gpoPath);
-        return false;
-    };
-
-    // Write placeholder magic; will be promoted to GPO_MAGIC only on final committed rewrite.
-    // If power is lost mid-creation, verifyGpo rejects "GPOT" and triggers a clean rebuild next boot.
-    memcpy(sCreateHeader.magic, GPO_MAGIC_PLACEHOLDER, 4);
-    sCreateHeader.romSize = romSize;
-    sCreateHeader.patchedRomSize = 0;  // filled in after Pass 1
-    sCreateHeader.ipsSize = ipsSize;
-    sCreateHeader.ipsTimestamp = ipsTime;
-    sCreateHeader.clusterSize = clusterSize;
-    memset(sCreateHeader.bitmask, 0, sizeof(sCreateHeader.bitmask));
-
-    char ipsHeader[5];
-    UINT br;
-    if (f_read(&sIpsFile, ipsHeader, 5, &br) != FR_OK || br != 5 || memcmp(ipsHeader, "PATCH", 5) != 0)
-        return cleanupAndAbort();
-
-    u32 maxHunkExtent = 0;
-    bool eofReached = false;
-
-    // Pass 1: scan IPS to identify patched clusters and find max hunk extent
-    while (true)
-    {
-        u8 offsetBuf[3];
-        if (f_read(&sIpsFile, offsetBuf, 3, &br) != FR_OK || br != 3) break;
-        u32 offset = ((u32)offsetBuf[0] << 16) | ((u32)offsetBuf[1] << 8) | offsetBuf[2];
-
-        // SNESTool EOF ambiguity fix: treat 0x454F46 as EOF only if <= 3 bytes remain.
-        // A real hunk at this offset would need at least 2 size bytes + 1 data byte.
-        if (offset == 0x454F46 && (ipsSize - (u32)f_tell(&sIpsFile)) <= 3)
-        {
-            eofReached = true;
-            break;
-        }
-
-        u8 sizeBuf[2];
-        if (f_read(&sIpsFile, sizeBuf, 2, &br) != FR_OK || br != 2) break;
-        u32 size = ((u32)sizeBuf[0] << 8) | sizeBuf[1];
-
-        if (size > 0)
-        {
-            if (offset + size > maxHunkExtent) maxHunkExtent = offset + size;
-
-            u32 startBlock = offset / 4096;
-            u32 endBlock   = (offset + size - 1) / 4096;
-            u32 blocksPerCluster = clusterSize / 4096;
-            if (blocksPerCluster == 0) blocksPerCluster = 1;
-            for (u32 b = startBlock; b <= endBlock; b++)
-            {
-                u32 c = b / blocksPerCluster;
-                if (c < 8192)
-                    sCreateHeader.bitmask[c / 32] |= (1u << (c % 32));
-            }
-            if (f_lseek(&sIpsFile, f_tell(&sIpsFile) + size) != FR_OK)
-                return cleanupAndAbort();
-        }
-        else
-        {
-            u8 countBuf[2];
-            if (f_read(&sIpsFile, countBuf, 2, &br) != FR_OK || br != 2) break;
-            u32 count = ((u32)countBuf[0] << 8) | countBuf[1];
-            if (count == 0) return cleanupAndAbort();  // corrupt RLE: infinite loop guard
-
-            u8 val;
-            if (f_read(&sIpsFile, &val, 1, &br) != FR_OK || br != 1) break;
-
-            if (offset + count > maxHunkExtent) maxHunkExtent = offset + count;
-
-            u32 startBlock = offset / 4096;
-            u32 endBlock   = (offset + count - 1) / 4096;
-            u32 blocksPerCluster = clusterSize / 4096;
-            if (blocksPerCluster == 0) blocksPerCluster = 1;
-            for (u32 b = startBlock; b <= endBlock; b++)
-            {
-                u32 c = b / blocksPerCluster;
-                if (c < 8192)
-                    sCreateHeader.bitmask[c / 32] |= (1u << (c % 32));
-            }
-        }
-    }
-
-    if (!eofReached) return cleanupAndAbort();
-
-    // Truncate field: IPS may have 3 optional bytes after EOF marker specifying new ROM size
-    u32 truncateValue = 0;
-    {
-        FSIZE_t remaining = ipsSize - f_tell(&sIpsFile);
-        if (remaining == 3)
-        {
-            u8 truncBuf[3];
-            if (f_read(&sIpsFile, truncBuf, 3, &br) == FR_OK && br == 3)
-                truncateValue = ((u32)truncBuf[0] << 16) | ((u32)truncBuf[1] << 8) | truncBuf[2];
-        }
-    }
-
-    // Effective ROM size after patch
-    u32 patchedRomSize = truncateValue > 0
-        ? truncateValue
-        : (maxHunkExtent > romSize ? maxHunkExtent : romSize);
-    sCreateHeader.patchedRomSize = patchedRomSize;
-
-    u32 totalRomClusters     = (romSize        + clusterSize - 1) / clusterSize;
-    u32 patchedTotalClusters = (patchedRomSize  + clusterSize - 1) / clusterSize;
-
-    // Clear bitmask bits outside [0, min(totalRomClusters, patchedTotalClusters)).
-    // Extension clusters do not use the bitmask; truncated-away clusters must not either.
-    u32 cleanBound = totalRomClusters < patchedTotalClusters
-        ? totalRomClusters : patchedTotalClusters;
-    for (u32 c = cleanBound; c < 8192; c++)
-        sCreateHeader.bitmask[c / 32] &= ~(1u << (c % 32));
-
-    // Write placeholder header (GPOT magic); promoted to GPO1 only at the end
-    UINT bw;
-    if (f_write(&sWriteGpoFile, &sCreateHeader, sizeof(sCreateHeader), &bw) != FR_OK
-        || bw != sizeof(sCreateHeader))
-        return cleanupAndAbort();
-
-    // Pad header cluster to clusterSize
-    memset(sTempBuf, 0, sizeof(sTempBuf));
-    u32 paddingBytes = clusterSize - sizeof(sCreateHeader);
-    while (paddingBytes > 0)
-    {
-        u32 chunk = paddingBytes > sizeof(sTempBuf) ? (u32)sizeof(sTempBuf) : paddingBytes;
-        if (f_write(&sWriteGpoFile, sTempBuf, chunk, &bw) != FR_OK || bw != chunk)
-            return cleanupAndAbort();
-        paddingBytes -= chunk;
-    }
-
-    // Range A: copy ROM clusters that the IPS touches, up to min(totalRomClusters, patchedTotalClusters)
-    u32 rangeALimit = totalRomClusters < patchedTotalClusters
-        ? totalRomClusters : patchedTotalClusters;
-    for (u32 c = 0; c < rangeALimit; c++)
-    {
-        if (c >= 8192 || !(sCreateHeader.bitmask[c / 32] & (1u << (c % 32))))
-            continue;
-
-        if (f_lseek(&sRomFile, (FSIZE_t)c * clusterSize) != FR_OK)
-            return cleanupAndAbort();
-
-        u32 remaining = clusterSize;
-        while (remaining > 0)
-        {
-            u32 chunk = remaining > sizeof(sTempBuf) ? (u32)sizeof(sTempBuf) : remaining;
-            memset(sTempBuf, 0xFF, chunk);  // pre-fill so short reads yield open-bus 0xFF
-            if (f_read(&sRomFile, sTempBuf, chunk, &br) != FR_OK)
-                return cleanupAndAbort();
-            if (f_write(&sWriteGpoFile, sTempBuf, chunk, &bw) != FR_OK || bw != chunk)
-                return cleanupAndAbort();
-            remaining -= chunk;
-        }
-    }
-
-    // Range B: extension clusters (past original ROM end), filled with 0xFF open-bus value.
-    // The IPS apply phase (Pass 2) will overwrite the relevant bytes afterward.
-    if (patchedTotalClusters > totalRomClusters)
-    {
-        memset(sTempBuf, 0xFF, sizeof(sTempBuf));
-        for (u32 c = totalRomClusters; c < patchedTotalClusters; c++)
-        {
-            u32 remaining = clusterSize;
-            while (remaining > 0)
-            {
-                u32 chunk = remaining > sizeof(sTempBuf) ? (u32)sizeof(sTempBuf) : remaining;
-                if (f_write(&sWriteGpoFile, sTempBuf, chunk, &bw) != FR_OK || bw != chunk)
-                    return cleanupAndAbort();
-                remaining -= chunk;
-            }
-        }
-    }
-
-    // Pass 2: Apply IPS patches to GPO file
-    if (f_lseek(&sIpsFile, 5) != FR_OK) return cleanupAndAbort();
-
-    // Precompute patched ROM cluster count (scoped to ROM region only; extension clusters use no bitmask bits)
-    u32 patchedRomClusterCount = 0;
-    for (u32 c = 0; c < totalRomClusters; c++)
-        if (c < 8192 && (sCreateHeader.bitmask[c / 32] & (1u << (c % 32))))
-            patchedRomClusterCount++;
-
-    // writePatchToGpo: apply a contiguous data buffer to the GPO file at the right cluster offset.
-    // Returns false on any I/O error (caller must cleanupAndAbort).
-    auto writePatchToGpo = [&](u32 romOffset, const u8* data, u32 dataSize) -> bool {
-        u32 startCluster = romOffset / clusterSize;
-        u32 endCluster   = (romOffset + dataSize - 1) / clusterSize;
-        for (u32 c = startCluster; c <= endCluster; c++)
-        {
-            if (c >= patchedTotalClusters) continue;  // truncation guard
-
-            u32 clusterStartOffset = c * clusterSize;
-            u32 clusterEndOffset   = clusterStartOffset + clusterSize;
-            u32 patchStart = romOffset > clusterStartOffset ? romOffset : clusterStartOffset;
-            u32 patchEnd   = (romOffset + dataSize) < clusterEndOffset
-                             ? (romOffset + dataSize) : clusterEndOffset;
-            if (patchStart >= patchEnd) continue;
-
-            u32 gpoIdx;
-            if (c >= totalRomClusters)
-            {
-                // Extension cluster: sequential after all patched ROM clusters in GPO
-                gpoIdx = patchedRomClusterCount + (c - totalRomClusters);
-            }
-            else
-            {
-                // c < 8192 guard: small-cluster SD cards can have totalRomClusters > 8192
-                if (c >= 8192 || !(sCreateHeader.bitmask[c / 32] & (1u << (c % 32)))) continue;
-                gpoIdx = 0;
-                for (u32 i = 0; i < c / 32; i++)
-                    gpoIdx += gPopCountTable.PopCount(sCreateHeader.bitmask[i]);
-                gpoIdx += gPopCountTable.PopCount(sCreateHeader.bitmask[c / 32] & ((1u << (c % 32)) - 1));
-            }
-
-            u32 targetFileOffset = clusterSize + gpoIdx * clusterSize + (patchStart - clusterStartOffset);
-            UINT bw2;
-            if (f_lseek(&sWriteGpoFile, targetFileOffset) != FR_OK) return false;
-            if (f_write(&sWriteGpoFile, data + (patchStart - romOffset), patchEnd - patchStart, &bw2) != FR_OK
-                || bw2 != (patchEnd - patchStart)) return false;
-        }
-        return true;
-    };
-
-    // writeRleToGpo: apply an RLE hunk to the GPO file.
-    // Returns false on any I/O error.
-    auto writeRleToGpo = [&](u32 romOffset, u8 val, u32 count) -> bool {
-        u32 startCluster = romOffset / clusterSize;
-        u32 endCluster   = (romOffset + count - 1) / clusterSize;
-        for (u32 c = startCluster; c <= endCluster; c++)
-        {
-            if (c >= patchedTotalClusters) continue;  // truncation guard
-
-            u32 clusterStartOffset = c * clusterSize;
-            u32 clusterEndOffset   = clusterStartOffset + clusterSize;
-            u32 patchStart = romOffset > clusterStartOffset ? romOffset : clusterStartOffset;
-            u32 patchEnd   = (romOffset + count) < clusterEndOffset
-                             ? (romOffset + count) : clusterEndOffset;
-            if (patchStart >= patchEnd) continue;
-
-            u32 gpoIdx;
-            if (c >= totalRomClusters)
-            {
-                gpoIdx = patchedRomClusterCount + (c - totalRomClusters);
-            }
-            else
-            {
-                if (c >= 8192 || !(sCreateHeader.bitmask[c / 32] & (1u << (c % 32)))) continue;
-                gpoIdx = 0;
-                for (u32 i = 0; i < c / 32; i++)
-                    gpoIdx += gPopCountTable.PopCount(sCreateHeader.bitmask[i]);
-                gpoIdx += gPopCountTable.PopCount(sCreateHeader.bitmask[c / 32] & ((1u << (c % 32)) - 1));
-            }
-
-            u32 targetFileOffset = clusterSize + gpoIdx * clusterSize + (patchStart - clusterStartOffset);
-            UINT bw2;
-            if (f_lseek(&sWriteGpoFile, targetFileOffset) != FR_OK) return false;
-
-            u32 writeLen = patchEnd - patchStart;
-            u32 fillSize = sizeof(sTempBuf) < clusterSize ? sizeof(sTempBuf) : clusterSize;
-            memset(sTempBuf, val, fillSize);
-            u32 remaining = writeLen;
-            while (remaining > 0)
-            {
-                u32 chunk = remaining > sizeof(sTempBuf) ? (u32)sizeof(sTempBuf) : remaining;
-                if (f_write(&sWriteGpoFile, sTempBuf, chunk, &bw2) != FR_OK || bw2 != chunk) return false;
-                remaining -= chunk;
-            }
-        }
-        return true;
-    };
-
-    bool pass2Eof = false;
-    while (true)
-    {
-        u8 offsetBuf[3];
-        if (f_read(&sIpsFile, offsetBuf, 3, &br) != FR_OK || br != 3) break;
-        u32 offset = ((u32)offsetBuf[0] << 16) | ((u32)offsetBuf[1] << 8) | offsetBuf[2];
-
-        if (offset == 0x454F46 && (ipsSize - (u32)f_tell(&sIpsFile)) <= 3)
-        {
-            pass2Eof = true;
-            break;
-        }
-
-        u8 sizeBuf[2];
-        if (f_read(&sIpsFile, sizeBuf, 2, &br) != FR_OK || br != 2) break;
-        u32 size = ((u32)sizeBuf[0] << 8) | sizeBuf[1];
-
-        if (size > 0)
-        {
-            u32 remaining = size;
-            u32 currentOffset = offset;
-            while (remaining > 0)
-            {
-                u32 chunk = remaining > sizeof(sTempBuf) ? (u32)sizeof(sTempBuf) : remaining;
-                if (f_read(&sIpsFile, sTempBuf, chunk, &br) != FR_OK || br != chunk)
-                    return cleanupAndAbort();
-                if (!writePatchToGpo(currentOffset, sTempBuf, chunk))
-                    return cleanupAndAbort();
-                currentOffset += chunk;
-                remaining -= chunk;
-            }
-        }
-        else
-        {
-            u8 countBuf[2];
-            if (f_read(&sIpsFile, countBuf, 2, &br) != FR_OK || br != 2) break;
-            u32 count = ((u32)countBuf[0] << 8) | countBuf[1];
-            if (count == 0) return cleanupAndAbort();
-
-            u8 val;
-            if (f_read(&sIpsFile, &val, 1, &br) != FR_OK || br != 1) break;
-
-            if (!writeRleToGpo(offset, val, count))
-                return cleanupAndAbort();
-        }
-    }
-
-    // A truncated IPS (no EOF marker in Pass 2) must not commit the GPO
-    if (!pass2Eof) return cleanupAndAbort();
-
-    // Final header commit: promote placeholder magic to GPO_MAGIC
-    memcpy(sCreateHeader.magic, GPO_MAGIC, 4);
-    if (f_lseek(&sWriteGpoFile, 0) != FR_OK) return cleanupAndAbort();
-    if (f_write(&sWriteGpoFile, &sCreateHeader, sizeof(sCreateHeader), &bw) != FR_OK
-        || bw != sizeof(sCreateHeader))
-        return cleanupAndAbort();
-
-    f_close(&sRomFile);
-    f_close(&sIpsFile);
-    f_close(&sWriteGpoFile);
-    return true;
-}
 
 struct ClmtTracker
 {
@@ -722,18 +223,60 @@ struct ClmtTracker
 }
 #endif
 
-extern "C" [[gnu::section(".ewram")]] bool gpo_init(const char* romPath)
+[[gnu::section(".ewram")]] static bool activateGpo(const char* gpoPath, u32 romSize)
 {
-    gpo_getPath(romPath, sIpsPath, ".ips");
+    if (f_open(&gGpoFile, gpoPath, FA_READ | FA_OPEN_EXISTING) != FR_OK) return false;
 
-    if (f_stat(sIpsPath, &sFnoIps) != FR_OK)
+    UINT br;
+    if (f_read(&gGpoFile, &sActiveGpoHeader, sizeof(sActiveGpoHeader), &br) != FR_OK
+        || br != sizeof(sActiveGpoHeader))
     {
+        f_close(&gGpoFile);
         return false;
     }
+
+    memcpy(gGpoBitmask, sActiveGpoHeader.bitmask, sizeof(gGpoBitmask));
+
+    sGpoClusterTable[0] = sizeof(sGpoClusterTable) / sizeof(DWORD);
+    gGpoFile.cltbl = sGpoClusterTable;
+    if (f_lseek(&gGpoFile, CREATE_LINKMAP) != FR_OK)
+    {
+        f_close(&gGpoFile);
+        return false;
+    }
+
+    u32 activeRomSize = sActiveGpoHeader.patchedRomSize > 0 ? sActiveGpoHeader.patchedRomSize : romSize;
+    if (!mergeClusterMaps(romSize, activeRomSize, sActiveGpoHeader.clusterSize))
+    {
+        f_close(&gGpoFile);
+        return false;
+    }
+
+    // Update SdCache bounds before swapping the CLMT; SdCache uses gFile.obj.objsize as
+    // the upper bound for read validation. Must be set before gFile.cltbl so that the
+    // first f_read after the swap sees the correct limit.
+    gFile.obj.objsize = activeRomSize;
+    gFile.cltbl = sMergedClusterTable;
+    return true;
+}
+
+extern "C" [[gnu::section(".ewram")]] GpoInitResult gpo_init(const char* romPath)
+{
+    gpo_getPath(romPath, sUpsPath, ".ups");
+    gpo_getPath(romPath, sIpsPath, ".ips");
+
+    bool hasUps = f_stat(sUpsPath, &sFnoUps) == FR_OK;
+    bool hasIps = f_stat(sIpsPath, &sFnoIps) == FR_OK;
+    if (!hasUps && !hasIps) return GpoInitResult::Inactive;
 
 #ifndef NDEBUG
     gpo_runUnitTests();
 #endif
+
+    FILINFO fnoRom;
+    if (f_stat(romPath, &fnoRom) != FR_OK) return GpoInitResult::Inactive;
+    u32 romSize = fnoRom.fsize;
+    u32 clusterSize = gFile.obj.fs->csize * 512;
 
     gpo_getPath(romPath, sGpoPath, ".gpo");
 
@@ -741,37 +284,64 @@ extern "C" [[gnu::section(".ewram")]] bool gpo_init(const char* romPath)
     gpo_getPath(romPath, sLogPath, "_gpo.log");
     f_unlink(sLogPath);
     log_debug(romPath, "=== GPO INIT ===");
+    log_debug(romPath, "ROM size loaded:", romSize, 0);
+    log_debug(romPath, "Cluster size of SD card:", clusterSize);
+    if (hasUps && hasIps)
+        log_debug(romPath, "Both .ups and .ips present; using .ups, ignoring .ips");
 #endif
 
-    if (f_stat(romPath, &sFnoRom) != FR_OK)
+    if (hasUps)
     {
+        u32 upsSize = sFnoUps.fsize;
+        u32 upsTimestamp = sFnoUps.fdate | (sFnoUps.ftime << 16);
+
+        if (!verifyGpo(sGpoPath, romSize, upsSize, upsTimestamp, (u8)GpoPatchKind::Ups, clusterSize))
+        {
 #ifndef NDEBUG
-        log_debug(romPath, "No ROM file found at path:", 0, 0);
+            log_debug(romPath, "GPO signature mismatch or file missing. Generating GPO patch from UPS...");
 #endif
-        return false;
+            bool crcMismatch = false;
+            if (!createGpoFromUps(romPath, sUpsPath, sGpoPath, romSize, upsSize, upsTimestamp,
+                                   clusterSize, &crcMismatch))
+            {
+#ifndef NDEBUG
+                log_debug(romPath, crcMismatch ? "createGpoFromUps failed: CRC mismatch!" : "createGpoFromUps failed!");
+#endif
+                return crcMismatch ? GpoInitResult::FatalMismatch : GpoInitResult::Inactive;
+            }
+#ifndef NDEBUG
+            log_debug(romPath, "createGpoFromUps succeeded!");
+#endif
+        }
+#ifndef NDEBUG
+        else
+        {
+            log_debug(romPath, "Existing GPO verified successfully.");
+        }
+#endif
+
+        bool ok = activateGpo(sGpoPath, romSize);
+#ifndef NDEBUG
+        log_debug(romPath, ok ? "GPO Patch initialized successfully!" : "activateGpo failed!");
+        if (ok) log_table(romPath, sMergedClusterTable);
+#endif
+        return ok ? GpoInitResult::Active : GpoInitResult::Inactive;
     }
 
-    u32 romSize = sFnoRom.fsize;
     u32 ipsSize = sFnoIps.fsize;
-    u32 ipsTime = sFnoIps.fdate | (sFnoIps.ftime << 16);
-    u32 clusterSize = gFile.obj.fs->csize * 512;
+    u32 ipsTimestamp = sFnoIps.fdate | (sFnoIps.ftime << 16);
 
-#ifndef NDEBUG
-    log_debug(romPath, "ROM/IPS size loaded:", romSize, ipsSize);
-    log_debug(romPath, "Cluster size of SD card:", clusterSize);
-#endif
-
-    if (!verifyGpo(sGpoPath, romSize, ipsSize, ipsTime, clusterSize))
+    if (!verifyGpo(sGpoPath, romSize, ipsSize, ipsTimestamp, (u8)GpoPatchKind::Ips, clusterSize))
     {
 #ifndef NDEBUG
         log_debug(romPath, "GPO signature mismatch or file missing. Generating GPO patch...");
 #endif
-        if (!createGpo(romPath, sIpsPath, sGpoPath, romSize, ipsSize, ipsTime, clusterSize))
+        if (!createGpoFromIps(romPath, sIpsPath, sGpoPath, romSize, ipsSize, ipsTimestamp, clusterSize))
         {
 #ifndef NDEBUG
             log_debug(romPath, "createGpo failed!");
 #endif
-            return false;
+            return GpoInitResult::Inactive;
         }
 #ifndef NDEBUG
         log_debug(romPath, "createGpo succeeded!");
@@ -784,66 +354,12 @@ extern "C" [[gnu::section(".ewram")]] bool gpo_init(const char* romPath)
     }
 #endif
 
-    if (f_open(&gGpoFile, sGpoPath, FA_READ | FA_OPEN_EXISTING) != FR_OK)
-    {
+    bool ok = activateGpo(sGpoPath, romSize);
 #ifndef NDEBUG
-        log_debug(romPath, "f_open gGpoFile failed!");
+    log_debug(romPath, ok ? "GPO Patch initialized successfully!" : "activateGpo failed!");
+    if (ok) log_table(romPath, sMergedClusterTable);
 #endif
-        return false;
-    }
-
-    UINT br;
-    if (f_read(&gGpoFile, &sVerifyHeader, sizeof(sVerifyHeader), &br) != FR_OK || br != sizeof(sVerifyHeader))
-    {
-#ifndef NDEBUG
-        log_debug(romPath, "f_read GpoHeader failed!");
-#endif
-        f_close(&gGpoFile);
-        return false;
-    }
-
-    memcpy(gGpoBitmask, sVerifyHeader.bitmask, sizeof(gGpoBitmask));
-
-    sGpoClusterTable[0] = sizeof(sGpoClusterTable) / sizeof(DWORD);
-    gGpoFile.cltbl = sGpoClusterTable;
-    if (f_lseek(&gGpoFile, CREATE_LINKMAP) != FR_OK)
-    {
-#ifndef NDEBUG
-        log_debug(romPath, "f_lseek CREATE_LINKMAP failed on gGpoFile!");
-#endif
-        f_close(&gGpoFile);
-        return false;
-    }
-
-#ifndef NDEBUG
-    log_debug(romPath, "sGpoClusterTable[0] size after CREATE_LINKMAP:", sGpoClusterTable[0]);
-#endif
-
-    u32 activeRomSize = sVerifyHeader.patchedRomSize > 0
-        ? sVerifyHeader.patchedRomSize : romSize;
-
-    if (!mergeClusterMaps(romSize, activeRomSize, clusterSize))
-    {
-#ifndef NDEBUG
-        log_debug(romPath, "mergeClusterMaps failed!");
-#endif
-        f_close(&gGpoFile);
-        return false;
-    }
-
-    // Update SdCache bounds before swapping the CLMT; SdCache uses gFile.obj.objsize as
-    // the upper bound for read validation. Must be set before gFile.cltbl so that the
-    // first f_read after the swap sees the correct limit.
-    gFile.obj.objsize = activeRomSize;
-    gFile.cltbl = sMergedClusterTable;
-
-#ifndef NDEBUG
-    log_debug(romPath, "mergeClusterMaps succeeded!");
-    log_table(romPath, sMergedClusterTable);
-    log_debug(romPath, "GPO Patch initialized successfully!");
-#endif
-
-    return true;
+    return ok ? GpoInitResult::Active : GpoInitResult::Inactive;
 }
 
 // After the linear chunk is loaded via f_read, FatFS serves cluster 0 from gFile.obj.sclust
@@ -853,9 +369,9 @@ extern "C" [[gnu::section(".ewram")]] bool gpo_init(const char* romPath)
 // Extension clusters inside the window (only possible on ROMs < 2MB) are also loaded here.
 extern "C" [[gnu::section(".ewram")]] void gpo_patchLinearChunk(u32 clusterSize, u32 linearChunkSize)
 {
-    u32 romSize          = sVerifyHeader.romSize;
-    u32 patchedRomSize   = sVerifyHeader.patchedRomSize > 0
-                           ? sVerifyHeader.patchedRomSize : (u32)gFile.obj.objsize;
+    u32 romSize          = sActiveGpoHeader.romSize;
+    u32 patchedRomSize   = sActiveGpoHeader.patchedRomSize > 0
+                           ? sActiveGpoHeader.patchedRomSize : (u32)gFile.obj.objsize;
     u32 totalRomClusters     = (romSize       + clusterSize - 1) / clusterSize;
     u32 patchedTotalClusters = (patchedRomSize + clusterSize - 1) / clusterSize;
 

--- a/code/core/arm9/source/Patches/GpoPatcher.h
+++ b/code/core/arm9/source/Patches/GpoPatcher.h
@@ -2,19 +2,24 @@
 #include "common.h"
 #include "Fat/ff.h"
 
-#define GPO_MAGIC "GPO1"
+#define GPO_MAGIC "GPO2"
 #define GPO_MAGIC_PLACEHOLDER "GPOT"
+
+enum class GpoPatchKind : u8 { Ips = 0, Ups = 1 };
 
 struct GpoHeader
 {
     char magic[4];
-    u32 romSize;
-    u32 patchedRomSize;      // effective ROM size after patch; 0 means same as romSize
-    u32 ipsSize;
-    u32 ipsTimestamp;
-    u32 clusterSize;
-    u32 bitmask[8192 / 32];
+    u32  romSize;
+    u32  patchedRomSize;      // effective ROM size after patch; 0 means same as romSize
+    u32  patchSize;           // was ipsSize
+    u32  patchTimestamp;      // was ipsTimestamp
+    u8   patchKind;           // GpoPatchKind, stored as u8 for a stable on-disk layout
+    u32  clusterSize;
+    u32  bitmask[8192 / 32];
 };
+
+enum class GpoInitResult { Inactive, Active, FatalMismatch };
 
 extern FIL gGpoFile;
 extern u32 gGpoBitmask[8192 / 32];
@@ -23,7 +28,7 @@ extern u32 gGpoBitmask[8192 / 32];
 extern "C" {
 #endif
 
-bool gpo_init(const char* romPath);
+GpoInitResult gpo_init(const char* romPath);
 void gpo_patchLinearChunk(u32 clusterSize, u32 linearChunkSize);
 
 #ifdef __cplusplus

--- a/code/core/arm9/source/Patches/GpoPatcher.h
+++ b/code/core/arm9/source/Patches/GpoPatcher.h
@@ -1,0 +1,29 @@
+#pragma once
+#include "common.h"
+#include "Fat/ff.h"
+
+#define GPO_MAGIC "GPO\0"
+
+struct GpoHeader
+{
+    char magic[4];
+    u32 romSize;
+    u32 ipsSize;
+    u32 ipsTimestamp;
+    u32 clusterSize;
+    u32 bitmask[8192 / 32];
+};
+
+extern FIL gGpoFile;
+extern u32 gGpoBitmask[8192 / 32];
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool gpo_init(const char* romPath);
+void gpo_patchLinearChunk(u32 clusterSize, u32 linearChunkSize);
+
+#ifdef __cplusplus
+}
+#endif

--- a/code/core/arm9/source/Patches/GpoPatcher.h
+++ b/code/core/arm9/source/Patches/GpoPatcher.h
@@ -2,12 +2,14 @@
 #include "common.h"
 #include "Fat/ff.h"
 
-#define GPO_MAGIC "GPO\0"
+#define GPO_MAGIC "GPO1"
+#define GPO_MAGIC_PLACEHOLDER "GPOT"
 
 struct GpoHeader
 {
     char magic[4];
     u32 romSize;
+    u32 patchedRomSize;      // effective ROM size after patch; 0 means same as romSize
     u32 ipsSize;
     u32 ipsTimestamp;
     u32 clusterSize;

--- a/code/core/arm9/source/Patches/UpsPatcher.cpp
+++ b/code/core/arm9/source/Patches/UpsPatcher.cpp
@@ -1,0 +1,456 @@
+#include "UpsPatcher.h"
+#include "GpoBuilder.h"
+#include "Crc32Table.h"
+#include <string.h>
+
+// Start with crc = 0xFFFFFFFF; after all data is fed, the final CRC32 is crc32_update(...) ^ 0xFFFFFFFF.
+[[gnu::section(".ewram")]] static u32 crc32_update(u32 crc, const u8* data, u32 len)
+{
+    for (u32 i = 0; i < len; i++)
+        crc = gCrc32Table.Table((u8)((crc ^ data[i]) & 0xFF)) ^ (crc >> 8);
+    return crc;
+}
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static FIL sRomFile;
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static FIL sUpsFile;
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static FIL sWriteGpoFile;
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static GpoHeader sCreateHeader;
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static u8 sUpsApplyBuf[4096];
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static u8 sSourceChunkBuf[4096];
+
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
+static u8 sXorOutBuf[4096];
+
+[[gnu::section(".ewram")]] static bool readVlv(FIL* f, u32* outValue)
+{
+    VlvDecoder dec;
+    while (true)
+    {
+        u8 b;
+        UINT br;
+        if (f_read(f, &b, 1, &br) != FR_OK || br != 1) return false;
+        if (dec.Feed(b))
+        {
+            *outValue = dec.value;
+            return true;
+        }
+    }
+}
+
+[[gnu::section(".ewram")]] static bool upsScanPass1(u32 patchedRomSize, u32 clusterSize, u32 recordsEndPos)
+{
+    u32 blocksPerCluster = clusterSize / 4096;
+    if (blocksPerCluster == 0) blocksPerCluster = 1;
+
+    u32 cursor = 0;
+    while ((u32)f_tell(&sUpsFile) < recordsEndPos)
+    {
+        u32 delta;
+        if (!readVlv(&sUpsFile, &delta)) return false;
+        cursor += delta;
+        if (cursor >= patchedRomSize) return false; // malformed: record starts past declared target size
+
+        u32 recordStart = cursor;
+        while (true)
+        {
+            u8 patchByte;
+            UINT br;
+            if (f_read(&sUpsFile, &patchByte, 1, &br) != FR_OK || br != 1) return false;
+            cursor++;
+            if (cursor > patchedRomSize) return false; // malformed: span exceeds declared target size
+            if (patchByte == 0) break;
+        }
+
+        u32 spanLen = cursor - recordStart;
+        u32 startBlock = recordStart / 4096;
+        u32 endBlock   = (recordStart + spanLen - 1) / 4096;
+        for (u32 b = startBlock; b <= endBlock; b++)
+        {
+            u32 c = b / blocksPerCluster;
+            if (c < 8192)
+                sCreateHeader.bitmask[c / 32] |= (1u << (c % 32));
+        }
+    }
+    return true;
+}
+
+[[gnu::section(".ewram")]] static bool flushUpsChunk(u32 offset, const u8* patchBytes, u32 len, u32 romSize)
+{
+    u32 sourceAvailable = offset < romSize ? (romSize - offset) : 0;
+    u32 sourceLen = len < sourceAvailable ? len : sourceAvailable;
+
+    if (sourceLen > 0)
+    {
+        if (f_lseek(&sRomFile, offset) != FR_OK) return false;
+        UINT br;
+        if (f_read(&sRomFile, sSourceChunkBuf, sourceLen, &br) != FR_OK || br != sourceLen) return false;
+    }
+
+    for (u32 i = 0; i < len; i++)
+    {
+        u8 sourceByte = i < sourceLen ? sSourceChunkBuf[i] : 0;
+        sXorOutBuf[i] = sourceByte ^ patchBytes[i];
+    }
+
+    return writePatchToGpo(&sWriteGpoFile, sCreateHeader, offset, sXorOutBuf, len);
+}
+
+[[gnu::section(".ewram")]] static bool upsApplyPass2(u32 romSize, u32 patchedRomSize, u32 recordsEndPos)
+{
+    u32 cursor = 0;
+    while ((u32)f_tell(&sUpsFile) < recordsEndPos)
+    {
+        u32 delta;
+        if (!readVlv(&sUpsFile, &delta)) return false;
+        cursor += delta;
+        if (cursor >= patchedRomSize) return false;
+
+        u32 bufLen = 0;
+        u32 flushStart = cursor;
+
+        while (true)
+        {
+            u8 patchByte;
+            UINT br;
+            if (f_read(&sUpsFile, &patchByte, 1, &br) != FR_OK || br != 1) return false;
+
+            sUpsApplyBuf[bufLen++] = patchByte;
+            cursor++;
+            if (cursor > patchedRomSize) return false;
+
+            bool terminated = (patchByte == 0);
+            if (bufLen == sizeof(sUpsApplyBuf) || terminated)
+            {
+                if (!flushUpsChunk(flushStart, sUpsApplyBuf, bufLen, romSize)) return false;
+                flushStart += bufLen;
+                bufLen = 0;
+            }
+
+            if (terminated) break;
+        }
+    }
+    return true;
+}
+
+// Debug log codes for createGpoFromUps, val1=code, val2=context-dependent. All share one
+// format string (the compiler folds repeated identical string literals into one .rodata
+// entry) rather than ~25 distinct messages, since that .rodata still has to fit in the
+// small `vrama` linker region shared with .text/.data/.bss on this target.
+//  1 clusterSize<sizeof(GpoHeader)   2 upsSize too short        3 f_open rom failed
+//  4 f_open ups failed               5 bad UPS1 magic           6 sourceSize VLV failed
+//  7 targetSize VLV failed           8 declaredSourceSize       9 declaredTargetSize
+// 10 declaredSourceSize!=romSize    11 recordsStartPos OOB      12 CRC footer read failed
+// 13 expectedSourceCrc              14 expectedTargetCrc        15 expectedPatchCrc
+// 16 source CRC32 read failed      17 computed source CRC32    18 source CRC32 mismatch
+// 19 patch CRC32 read failed       20 computed patch CRC32     21 patch CRC32 mismatch
+// 22 upsScanPass1 failed           23 upsScanPass1 OK           24 f_open gpo failed
+// 25 header write failed           26 header padding failed    27 header+padding OK
+// 28 copyRangeAClusters failed     29 writeRangeBExtension failed 30 Range A/B OK
+// 31 upsApplyPass2 failed          32 upsApplyPass2 OK          33 Pass3 GPO read failed
+// 34 Pass3 ROM read failed         35 computed target CRC32     36 target CRC32 mismatch
+// 37 final magic-commit failed     38 completed successfully
+#ifndef NDEBUG
+#define UPS_LOG(romPath, code, val) log_debug(romPath, "createGpoFromUps step:", code, val)
+#else
+#define UPS_LOG(romPath, code, val) ((void)0)
+#endif
+
+[[gnu::section(".ewram")]] bool createGpoFromUps(const char* romPath, const char* upsPath, const char* gpoPath,
+                                                    u32 romSize, u32 upsSize, u32 upsTimestamp, u32 clusterSize,
+                                                    bool* outCrcMismatch)
+{
+    *outCrcMismatch = false;
+    if (clusterSize < sizeof(GpoHeader))
+    {
+        UPS_LOG(romPath, 1, clusterSize);
+        return false;
+    }
+    if (upsSize < 4 + 1 + 1 + 12)
+    {
+        UPS_LOG(romPath, 2, upsSize);
+        return false;
+    }
+
+    if (f_open(&sRomFile, romPath, FA_READ | FA_OPEN_EXISTING) != FR_OK)
+    {
+        UPS_LOG(romPath, 3, 0);
+        return false;
+    }
+    if (f_open(&sUpsFile, upsPath, FA_READ | FA_OPEN_EXISTING) != FR_OK)
+    {
+        UPS_LOG(romPath, 4, 0);
+        f_close(&sRomFile);
+        return false;
+    }
+
+    auto abortParse = [&]() -> bool {
+        f_close(&sRomFile);
+        f_close(&sUpsFile);
+        return false;
+    };
+
+    char magic[4];
+    UINT br;
+    if (f_read(&sUpsFile, magic, 4, &br) != FR_OK || br != 4 || memcmp(magic, "UPS1", 4) != 0)
+    {
+        UPS_LOG(romPath, 5, 0);
+        return abortParse();
+    }
+
+    u32 declaredSourceSize, declaredTargetSize;
+    if (!readVlv(&sUpsFile, &declaredSourceSize))
+    {
+        UPS_LOG(romPath, 6, 0);
+        return abortParse();
+    }
+    if (!readVlv(&sUpsFile, &declaredTargetSize))
+    {
+        UPS_LOG(romPath, 7, 0);
+        return abortParse();
+    }
+    UPS_LOG(romPath, 8, declaredSourceSize);
+    UPS_LOG(romPath, 9, declaredTargetSize);
+    if (declaredSourceSize != romSize)
+    {
+        UPS_LOG(romPath, 10, declaredSourceSize);
+        return abortParse();
+    }
+
+    u32 recordsStartPos = (u32)f_tell(&sUpsFile);
+    if (upsSize < 12 || recordsStartPos > upsSize - 12)
+    {
+        UPS_LOG(romPath, 11, recordsStartPos);
+        return abortParse();
+    }
+    u32 recordsEndPos = upsSize - 12;
+
+    u32 expectedSourceCrc, expectedTargetCrc, expectedPatchCrc;
+    if (f_lseek(&sUpsFile, recordsEndPos) != FR_OK) return abortParse();
+    u8 crcFieldBuf[12];
+    if (f_read(&sUpsFile, crcFieldBuf, 12, &br) != FR_OK || br != 12)
+    {
+        UPS_LOG(romPath, 12, 0);
+        return abortParse();
+    }
+    expectedSourceCrc = crcFieldBuf[0] | (crcFieldBuf[1] << 8) | (crcFieldBuf[2] << 16) | ((u32)crcFieldBuf[3] << 24);
+    expectedTargetCrc = crcFieldBuf[4] | (crcFieldBuf[5] << 8) | (crcFieldBuf[6] << 16) | ((u32)crcFieldBuf[7] << 24);
+    expectedPatchCrc  = crcFieldBuf[8] | (crcFieldBuf[9] << 8) | (crcFieldBuf[10] << 16) | ((u32)crcFieldBuf[11] << 24);
+    UPS_LOG(romPath, 13, expectedSourceCrc);
+    UPS_LOG(romPath, 14, expectedTargetCrc);
+    UPS_LOG(romPath, 15, expectedPatchCrc);
+
+    u32 srcCrc = 0xFFFFFFFF;
+    if (f_lseek(&sRomFile, 0) != FR_OK) return abortParse();
+    {
+        u32 remaining = romSize;
+        while (remaining > 0)
+        {
+            u32 chunk = remaining > sizeof(sUpsApplyBuf) ? (u32)sizeof(sUpsApplyBuf) : remaining;
+            if (f_read(&sRomFile, sUpsApplyBuf, chunk, &br) != FR_OK || br != chunk)
+            {
+                UPS_LOG(romPath, 16, remaining);
+                return abortParse();
+            }
+            srcCrc = crc32_update(srcCrc, sUpsApplyBuf, chunk);
+            remaining -= chunk;
+        }
+    }
+    srcCrc ^= 0xFFFFFFFF;
+    UPS_LOG(romPath, 17, srcCrc);
+    if (srcCrc != expectedSourceCrc) { UPS_LOG(romPath, 18, srcCrc); *outCrcMismatch = true; return abortParse(); }
+
+    u32 patchCrc = 0xFFFFFFFF;
+    if (f_lseek(&sUpsFile, 0) != FR_OK) return abortParse();
+    {
+        u32 remaining = upsSize - 4;
+        while (remaining > 0)
+        {
+            u32 chunk = remaining > sizeof(sUpsApplyBuf) ? (u32)sizeof(sUpsApplyBuf) : remaining;
+            if (f_read(&sUpsFile, sUpsApplyBuf, chunk, &br) != FR_OK || br != chunk)
+            {
+                UPS_LOG(romPath, 19, remaining);
+                return abortParse();
+            }
+            patchCrc = crc32_update(patchCrc, sUpsApplyBuf, chunk);
+            remaining -= chunk;
+        }
+    }
+    patchCrc ^= 0xFFFFFFFF;
+    UPS_LOG(romPath, 20, patchCrc);
+    if (patchCrc != expectedPatchCrc) { UPS_LOG(romPath, 21, patchCrc); *outCrcMismatch = true; return abortParse(); }
+
+    memset(&sCreateHeader, 0, sizeof(sCreateHeader));
+    if (f_lseek(&sUpsFile, recordsStartPos) != FR_OK) return abortParse();
+    // No bitmask-cleanup pass needed here unlike IPS: upsScanPass1's `cursor >= patchedRomSize`
+    // guard already prevents any bit at or past patchedTotalClusters from ever being set.
+    if (!upsScanPass1(declaredTargetSize, clusterSize, recordsEndPos))
+    {
+        UPS_LOG(romPath, 22, 0);
+        return abortParse();
+    }
+    UPS_LOG(romPath, 23, 0);
+
+    u32 patchedRomSize = declaredTargetSize;
+    memcpy(sCreateHeader.magic, GPO_MAGIC_PLACEHOLDER, 4);
+    sCreateHeader.romSize = romSize;
+    sCreateHeader.patchedRomSize = patchedRomSize;
+    sCreateHeader.patchSize = upsSize;
+    sCreateHeader.patchTimestamp = upsTimestamp;
+    sCreateHeader.patchKind = (u8)GpoPatchKind::Ups;
+    sCreateHeader.clusterSize = clusterSize;
+
+    // FA_READ is required (not just FA_WRITE) because Pass 3 below reads this same handle
+    // back to verify the target CRC32 -- FatFS enforces access-mode flags strictly, so a
+    // write-only handle would reject every f_read() in that pass.
+    if (f_open(&sWriteGpoFile, gpoPath, FA_READ | FA_WRITE | FA_CREATE_ALWAYS) != FR_OK)
+    {
+        UPS_LOG(romPath, 24, 0);
+        return abortParse();
+    }
+
+    auto abortBuild = [&]() -> bool {
+        f_close(&sRomFile);
+        f_close(&sUpsFile);
+        f_close(&sWriteGpoFile);
+        f_unlink(gpoPath);
+        return false;
+    };
+
+    UINT bw;
+    if (f_write(&sWriteGpoFile, &sCreateHeader, sizeof(sCreateHeader), &bw) != FR_OK || bw != sizeof(sCreateHeader))
+    {
+        UPS_LOG(romPath, 25, bw);
+        return abortBuild();
+    }
+    {
+        u32 paddingBytes = clusterSize - sizeof(sCreateHeader);
+        memset(sUpsApplyBuf, 0, sizeof(sUpsApplyBuf));
+        while (paddingBytes > 0)
+        {
+            u32 chunk = paddingBytes > sizeof(sUpsApplyBuf) ? (u32)sizeof(sUpsApplyBuf) : paddingBytes;
+            if (f_write(&sWriteGpoFile, sUpsApplyBuf, chunk, &bw) != FR_OK || bw != chunk)
+            {
+                UPS_LOG(romPath, 26, bw);
+                return abortBuild();
+            }
+            paddingBytes -= chunk;
+        }
+    }
+    UPS_LOG(romPath, 27, 0);
+
+    if (!copyRangeAClusters(&sWriteGpoFile, &sRomFile, sCreateHeader))
+    {
+        UPS_LOG(romPath, 28, 0);
+        return abortBuild();
+    }
+    if (!writeRangeBExtensionClusters(&sWriteGpoFile, sCreateHeader))
+    {
+        UPS_LOG(romPath, 29, 0);
+        return abortBuild();
+    }
+    UPS_LOG(romPath, 30, 0);
+
+    if (f_lseek(&sUpsFile, recordsStartPos) != FR_OK) return abortBuild();
+    if (!upsApplyPass2(romSize, patchedRomSize, recordsEndPos))
+    {
+        UPS_LOG(romPath, 31, 0);
+        return abortBuild();
+    }
+    UPS_LOG(romPath, 32, 0);
+
+    u32 targetCrc = 0xFFFFFFFF;
+    {
+        u32 patchedTotalClusters = (patchedRomSize + clusterSize - 1) / clusterSize;
+        for (u32 c = 0; c < patchedTotalClusters; c++)
+        {
+            u32 gpoOffset;
+            bool fromGpo = gpoClusterFileOffset(sCreateHeader, c, &gpoOffset);
+
+            u32 bytesInCluster = clusterSize;
+            if (c == patchedTotalClusters - 1)
+            {
+                u32 used = patchedRomSize - c * clusterSize;
+                if (used < clusterSize) bytesInCluster = used;
+            }
+
+            u32 remaining = bytesInCluster;
+            u32 byteOffsetInCluster = 0;
+            // For the unpatched-ROM-cluster branch, the cluster's bytes past
+            // romSize don't exist in sRomFile. Clamp the real read to the
+            // in-bounds portion and feed implicit zero bytes for the rest,
+            // matching flushUpsChunk's implicit-zero convention.
+            u32 realBytesInCluster = bytesInCluster;
+            if (!fromGpo)
+            {
+                u32 clusterStart = c * clusterSize;
+                u32 romAvailable = clusterStart < romSize ? (romSize - clusterStart) : 0;
+                if (romAvailable < realBytesInCluster) realBytesInCluster = romAvailable;
+            }
+            while (remaining > 0)
+            {
+                u32 chunk = remaining > sizeof(sUpsApplyBuf) ? (u32)sizeof(sUpsApplyBuf) : remaining;
+                if (fromGpo)
+                {
+                    if (f_lseek(&sWriteGpoFile, gpoOffset + byteOffsetInCluster) != FR_OK) return abortBuild();
+                    if (f_read(&sWriteGpoFile, sUpsApplyBuf, chunk, &br) != FR_OK || br != chunk)
+                    {
+                        UPS_LOG(romPath, 33, c);
+                        return abortBuild();
+                    }
+                }
+                else if (byteOffsetInCluster < realBytesInCluster)
+                {
+                    // Real bytes remain in this chunk; clamp this read to not
+                    // cross past realBytesInCluster, zero-fill the rest below.
+                    u32 realChunk = chunk;
+                    if (byteOffsetInCluster + realChunk > realBytesInCluster)
+                        realChunk = realBytesInCluster - byteOffsetInCluster;
+                    if (f_lseek(&sRomFile, (FSIZE_t)c * clusterSize + byteOffsetInCluster) != FR_OK) return abortBuild();
+                    if (f_read(&sRomFile, sUpsApplyBuf, realChunk, &br) != FR_OK || br != realChunk)
+                    {
+                        UPS_LOG(romPath, 34, c);
+                        return abortBuild();
+                    }
+                    if (realChunk < chunk) memset(sUpsApplyBuf + realChunk, 0, chunk - realChunk);
+                }
+                else
+                {
+                    // Entirely past romSize: implicit zero bytes, no read.
+                    memset(sUpsApplyBuf, 0, chunk);
+                }
+                targetCrc = crc32_update(targetCrc, sUpsApplyBuf, chunk);
+                byteOffsetInCluster += chunk;
+                remaining -= chunk;
+            }
+        }
+    }
+    targetCrc ^= 0xFFFFFFFF;
+    UPS_LOG(romPath, 35, targetCrc);
+    if (targetCrc != expectedTargetCrc) { UPS_LOG(romPath, 36, targetCrc); *outCrcMismatch = true; return abortBuild(); }
+
+    memcpy(sCreateHeader.magic, GPO_MAGIC, 4);
+    if (f_lseek(&sWriteGpoFile, 0) != FR_OK) return abortBuild();
+    if (f_write(&sWriteGpoFile, &sCreateHeader, sizeof(sCreateHeader), &bw) != FR_OK
+        || bw != sizeof(sCreateHeader))
+    {
+        UPS_LOG(romPath, 37, bw);
+        return abortBuild();
+    }
+    UPS_LOG(romPath, 38, 0);
+
+    f_close(&sRomFile);
+    f_close(&sUpsFile);
+    f_close(&sWriteGpoFile);
+    return true;
+}

--- a/code/core/arm9/source/Patches/UpsPatcher.h
+++ b/code/core/arm9/source/Patches/UpsPatcher.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "common.h"
+#include "Fat/ff.h"
+#include "GpoPatcher.h"
+
+struct VlvDecoder
+{
+    u32 value = 0;
+    u32 shift = 1;
+
+    // Feed one byte; returns true once this VLV value is complete.
+    bool Feed(u8 byte)
+    {
+        value += (u32)(byte & 0x7F) * shift;
+        if (byte & 0x80) return true;
+        shift <<= 7;
+        value += shift;
+        return false;
+    }
+};
+
+// outCrcMismatch is set true only when a fully-read CRC32 (source, target, or patch)
+// disagrees with the .ups header; any I/O or parse failure leaves it false.
+bool createGpoFromUps(const char* romPath, const char* upsPath, const char* gpoPath,
+                       u32 romSize, u32 upsSize, u32 upsTimestamp, u32 clusterSize,
+                       bool* outCrcMismatch);

--- a/code/core/arm9/source/main.cpp
+++ b/code/core/arm9/source/main.cpp
@@ -88,6 +88,12 @@ static void setupLogger()
         gLogger = &sNullLogger;
 }
 
+static void haltWithErrorScreen(u16 bgColor)
+{
+    GFX_PLTT_BG_MAIN[0] = bgColor;
+    while (1);
+}
+
 static bool mountDldi()
 {
     FRESULT res = f_mount(&gFatFs, "fat:", 1);
@@ -196,7 +202,11 @@ static void loadGbaRom(const char* romPath)
     memset(&gFile, 0, sizeof(gFile));
     f_open(&gFile, romPath, FA_OPEN_EXISTING | FA_READ);
     sdc_init();
-    bool gpoActive = gpo_init(romPath);
+    sSplashScreen->EnterBusyLoop();
+    GpoInitResult gpoResult = gpo_init(romPath);
+    if (gpoResult == GpoInitResult::FatalMismatch)
+        haltWithErrorScreen(0x1F | (0x1F << 5)); // yellow: UPS patch CRC32 doesn't match this ROM
+    bool gpoActive = gpoResult == GpoInitResult::Active;
     f_read(&gFile, &gRomHeader, sizeof(GbaHeader), &br);
     f_lseek(&gFile, ROM_LINEAR_GBA_ADDRESS - 0x08000000);
     f_read(&gFile, (void*)ROM_LINEAR_DS_ADDRESS, ROM_LINEAR_SIZE, &br);
@@ -481,8 +491,7 @@ extern "C" void gbaRunnerMain(int argc, char* argv[])
 
     if (!mountResult)
     {
-        GFX_PLTT_BG_MAIN[0] = 0x1F << 10;
-        while (1);
+        haltWithErrorScreen(0x1F << 10); // blue: SD/DLDI mount failure
     }
 
     // if (Environment::SupportsAgbSemihosting())
@@ -508,6 +517,7 @@ extern "C" void gbaRunnerMain(int argc, char* argv[])
     handleSave(romPath);
     SelfModifyingPatches().ApplyPatches(gAppSettingsService.GetAppSettings().runSettings);
 
+    sSplashScreen->ExitBusyLoop();
     waitSplashScreenAnimation();
     stopSplashScreenAnimation();
     delete sSplashScreen;

--- a/code/core/arm9/source/main.cpp
+++ b/code/core/arm9/source/main.cpp
@@ -29,6 +29,7 @@
 #include "Peripherals/Sound/GbaSound9.h"
 #include "Patches/HarvestMoonPatches.h"
 #include "Patches/BadMixerPatch.h"
+#include "Patches/GpoPatcher.h"
 #include "Application/Settings/AppSettingsService.h"
 #include "GbaHeader.h"
 #include "MemoryEmulator/MemoryLoadStore.h"
@@ -53,11 +54,11 @@
 #define SETTINGS_FILE_PATH              "/_gba/gbarunner3.json"
 #define GAME_SETTINGS_FILE_PATH_FORMAT  "/_gba/configs/%c%c%c%c%02X.json"
 
-[[gnu::section(".ewram.bss")]]
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
 FATFS gFatFs;
-[[gnu::section(".ewram.bss")]]
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
 FIL gFile;
-[[gnu::section(".ewram.bss")]]
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
 GbaHeader gRomHeader;
 
 [[gnu::section(".vramhi.bss")]]
@@ -73,7 +74,7 @@ u32 memu_biosOpcodes[4]
 };
 
 static NitroEmulatorOutputStream sIsNitroOutput;
-[[gnu::section(".ewram.bss")]]
+[[gnu::section(".ewram.bss"), gnu::aligned(32)]]
 static PlainLogger sPlainLogger { LogLevel::All, &sIsNitroOutput };
 static NullLogger sNullLogger;
 ILogger* gLogger;
@@ -195,9 +196,15 @@ static void loadGbaRom(const char* romPath)
     memset(&gFile, 0, sizeof(gFile));
     f_open(&gFile, romPath, FA_OPEN_EXISTING | FA_READ);
     sdc_init();
+    bool gpoActive = gpo_init(romPath);
     f_read(&gFile, &gRomHeader, sizeof(GbaHeader), &br);
     f_lseek(&gFile, ROM_LINEAR_GBA_ADDRESS - 0x08000000);
     f_read(&gFile, (void*)ROM_LINEAR_DS_ADDRESS, ROM_LINEAR_SIZE, &br);
+    if (gpoActive)
+    {
+        u32 clusterSize = gFile.obj.fs->csize * 512;
+        gpo_patchLinearChunk(clusterSize, ROM_LINEAR_SIZE);
+    }
 
     HarvestMoonPatches().TryApplyPatches(gRomHeader.gameCode);
     if (BadMixerPatch().TryApplyPatch())


### PR DESCRIPTION
Loads and applies IPS patches at boot by generating a `.gpo` sidecar file that stores pre-patched clusters. The FatFS cluster link-map is replaced with a merged table that transparently redirects patched cluster reads to the GPO file, with zero runtime overhead in the SD cache hot path.

**This build adds:**
- ROM extension support: IPS hunks past the original EOF now work (extension clusters appended to the GPO, `gFile.obj.objsize` updated)
- IPS truncate field handling
- SNESTool EOF ambiguity fix (offset `0x454F46` only treated as EOF when `<= 3` bytes remain)
- Power-loss guard: GPO is written with a `GPOT` placeholder and promoted to `GPO1` only on successful completion
- RLE count=0 guard, unchecked I/O fixes, file handle leak fixes

**Tested:**
- Boktai 1 (JPN DSi, DSpico flashcard)
- FFVI Advance with [FFVI Sound Restoration](https://www.romhacking.net/hacks/657/) (3.2MB IPS patch)

**Also adds UPS support:**
- `.ups` parsing (VLV decode, XOR delta apply) with CRC32 checks on source, target, and patch file, so a bad patch or wrong ROM gets caught instead of silently corrupting the boot
- `.ups` wins if both `.ups` and `.ips` are present
- Shared GPO-building logic moved into `GpoBuilder.cpp` so IPS and UPS don't duplicate it
- Boot splash glow now keeps pulsing through patch generation and the slow boot steps after it, instead of freezing

**Tested:**
- Mother 3 (Japan) with the [Mother 3 fan translation](https://mother3.fobby.net/)

Closes #16.